### PR TITLE
feat: Support CIMD + HTTP Message Signatures for Open Social auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,12 @@ OMDB_API_KEY=your-omdb-api-key-here
 OPENSOCIAL_API_URL=http://127.0.0.1:3001
 OPENSOCIAL_API_KEY=your-opensocial-api-key-here
 
+# CIMD / HTTP Message Signatures auth (preferred over API key when set)
+# Generate a key pair: openssl genpkey -algorithm ed25519 -out private.pem
+# OPENSOCIAL_SIGNING_KEY=<PEM-encoded private key>
+# OPENSOCIAL_KEY_ID=collective-social-key-1
+# OPENSOCIAL_KEY_ALGORITHM=ed25519
+
 # CORS - Frontend origin allowed in production
 # In production set to e.g. https://app.collectivesocial.app
 # In development this is ignored (localhost origins are allowed automatically)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,3 +29,6 @@ jobs:
                   containerAppName: collective-social-api
                   resourceGroup: open-collective-social
                   imageToDeploy: ${{ secrets.REGISTRY_LOGIN_SERVER }}/collective-social-api:${{ github.sha }}
+                  environmentVariables: >-
+                      OPENSOCIAL_SIGNING_KEY=${{ secrets.OPENSOCIAL_SIGNING_KEY }}
+                      OPENSOCIAL_KEY_ID=${{ secrets.OPENSOCIAL_KEY_ID }}

--- a/src/config.ts
+++ b/src/config.ts
@@ -59,5 +59,9 @@ export const config = {
     'CollectiveSocial.app/1.0 (contact@collectivesocial.app)',
   openSocialApiUrl: process.env.OPENSOCIAL_API_URL || 'http://127.0.0.1:3001',
   openSocialApiKey: process.env.OPENSOCIAL_API_KEY || '',
+  // CIMD / HTTP Message Signatures auth (preferred over API key when set)
+  openSocialSigningKey: process.env.OPENSOCIAL_SIGNING_KEY || '',
+  openSocialKeyId: process.env.OPENSOCIAL_KEY_ID || 'collective-social-key-1',
+  openSocialKeyAlgorithm: process.env.OPENSOCIAL_KEY_ALGORITHM || 'ed25519',
   corsOrigin: process.env.CORS_ORIGIN, // e.g. https://app.collectivesocial.app
 } as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,9 @@ app.use(
   cors({
     origin:
       config.nodeEnv === 'production'
-        ? (config.corsOrigin ? [config.corsOrigin] : [])
+        ? config.corsOrigin
+          ? [config.corsOrigin]
+          : []
         : ['http://127.0.0.1:5173', 'http://localhost:5173'],
     credentials: true,
   })
@@ -76,21 +78,25 @@ app.use((req, _res, next) => {
         const collection = decodeURIComponent(segments[1]);
         const rkey = decodeURIComponent(segments[2]);
         const atUri = `at://${did}/${collection}/${rkey}`;
-        const suffix = segments.length > 3 ? '/' + segments.slice(3).join('/') : '';
+        const suffix =
+          segments.length > 3 ? '/' + segments.slice(3).join('/') : '';
 
         // Recursively handle a second AT URI in the suffix (e.g. /items/:itemUri)
         let processedSuffix = suffix;
         const innerMatch = suffix.match(/\/at(?:%3A|:)\/{1,2}/i);
         if (innerMatch && innerMatch.index !== undefined) {
           const sPre = suffix.substring(0, innerMatch.index + 1);
-          const sAfterAt = suffix.substring(innerMatch.index + innerMatch[0].length);
+          const sAfterAt = suffix.substring(
+            innerMatch.index + innerMatch[0].length
+          );
           const innerSegs = sAfterAt.split('/');
           if (innerSegs.length >= 3) {
             const iDid = decodeURIComponent(innerSegs[0]);
             const iCol = decodeURIComponent(innerSegs[1]);
             const iRkey = decodeURIComponent(innerSegs[2]);
             const innerAtUri = `at://${iDid}/${iCol}/${iRkey}`;
-            const iSuffix = innerSegs.length > 3 ? '/' + innerSegs.slice(3).join('/') : '';
+            const iSuffix =
+              innerSegs.length > 3 ? '/' + innerSegs.slice(3).join('/') : '';
             processedSuffix = sPre + encodeURIComponent(innerAtUri) + iSuffix;
           }
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,27 @@ app.get('/health', (_req, res) => {
   res.json({ status: 'ok' });
 });
 
+// CIMD document — serves the public key for HTTP Message Signatures verification
+app.get('/.well-known/client-metadata.json', async (_req, res) => {
+  try {
+    if (!config.openSocialSigningKey) {
+      return res.status(404).json({ error: 'CIMD not configured' });
+    }
+    const { publicKeyToJwk } = await import('./lib/httpSigning');
+    const jwk = publicKeyToJwk(
+      config.openSocialSigningKey,
+      (config.openSocialKeyAlgorithm || 'ed25519') as any
+    );
+    res.json({
+      client_id: config.serviceUrl || `http://localhost:${config.port}`,
+      client_name: 'Collective Social',
+      jwks: { keys: [jwk] },
+    });
+  } catch {
+    res.status(500).json({ error: 'Failed to generate CIMD document' });
+  }
+});
+
 // Initialize app context and routes
 createAppContext().then((ctx) => {
   // Request logging with correlation IDs

--- a/src/lexicon/index.ts
+++ b/src/lexicon/index.ts
@@ -19,6 +19,9 @@ export class Server {
   xrpc: XrpcServer;
 
   constructor(options?: XrpcOptions) {
-    this.xrpc = createXrpcServer(schemas, options);
+    this.xrpc = createXrpcServer(
+      schemas as Parameters<typeof createXrpcServer>[0],
+      options
+    );
   }
 }

--- a/src/lib/httpSigning.ts
+++ b/src/lib/httpSigning.ts
@@ -1,0 +1,122 @@
+/**
+ * HTTP Message Signatures (RFC 9421) — request signing for outbound API calls.
+ *
+ * Signs requests to opensocial.community using the app's private key.
+ * The server verifies signatures using the public key from our CIMD document.
+ */
+
+import crypto from 'crypto';
+
+export interface SigningConfig {
+  /** PEM-encoded private key */
+  privateKey: string;
+  /** Key ID used in Signature-Input (matches the key ID in CIMD) */
+  keyId: string;
+  /** Signing algorithm: 'ed25519', 'ecdsa-p256', or 'rsa-pss-sha256' */
+  algorithm: 'ed25519' | 'ecdsa-p256' | 'rsa-pss-sha256';
+}
+
+interface RequestComponents {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body?: string;
+}
+
+/**
+ * Sign an outbound HTTP request per RFC 9421.
+ * Returns the headers to add to the request (Signature-Input + Signature).
+ */
+export function signRequest(
+  request: RequestComponents,
+  config: SigningConfig
+): { 'Signature-Input': string; Signature: string; 'Content-Digest'?: string } {
+  const { method, url, headers, body } = request;
+  const parsedUrl = new URL(url);
+
+  const created = Math.floor(Date.now() / 1000).toString();
+  const label = 'sig1';
+
+  // Determine which components to sign
+  const components: string[] = ['"@method"', '"@path"'];
+  const componentValues: string[] = [method.toUpperCase(), parsedUrl.pathname];
+
+  // Add content-digest for requests with body
+  const result: Record<string, string> = {};
+  if (body) {
+    const digest = crypto.createHash('sha256').update(body).digest('base64');
+    result['Content-Digest'] = `sha-256=:${digest}:`;
+    components.push('"content-digest"');
+    componentValues.push(result['Content-Digest']);
+  }
+
+  // Build signature base
+  const signatureBase = components
+    .map((comp, i) => `${comp}: ${componentValues[i]}`)
+    .join('\n');
+
+  const params = `(${components.join(' ')});created=${created};keyid="${config.keyId}"`;
+  const fullBase = `${signatureBase}\n"@signature-params": ${params}`;
+
+  // Sign
+  const signature = signWithKey(fullBase, config);
+  const sigBase64 = signature.toString('base64');
+
+  result['Signature-Input'] = `${label}=${params}`;
+  result['Signature'] = `${label}=:${sigBase64}:`;
+
+  return result as any;
+}
+
+function signWithKey(data: string, config: SigningConfig): Buffer {
+  const dataBuffer = Buffer.from(data, 'utf-8');
+
+  switch (config.algorithm) {
+    case 'ed25519':
+      return Buffer.from(crypto.sign(null, dataBuffer, config.privateKey));
+
+    case 'ecdsa-p256': {
+      const signer = crypto.createSign('SHA256');
+      signer.update(dataBuffer);
+      return signer.sign(config.privateKey);
+    }
+
+    case 'rsa-pss-sha256': {
+      const signer = crypto.createSign('SHA256');
+      signer.update(dataBuffer);
+      return signer.sign({
+        key: config.privateKey,
+        padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
+        saltLength: crypto.constants.RSA_PSS_SALTLEN_DIGEST,
+      });
+    }
+
+    default:
+      throw new Error(`Unsupported signing algorithm: ${config.algorithm}`);
+  }
+}
+
+/**
+ * Export the public key from a private key as JWK (for CIMD document).
+ */
+export function publicKeyToJwk(privateKeyPem: string, algorithm: SigningConfig['algorithm']): crypto.JsonWebKey {
+  const keyObj = crypto.createPublicKey(privateKeyPem);
+  const jwk = keyObj.export({ format: 'jwk' });
+
+  // Add alg field based on algorithm
+  switch (algorithm) {
+    case 'ed25519':
+      jwk.alg = 'EdDSA';
+      break;
+    case 'ecdsa-p256':
+      jwk.alg = 'ES256';
+      break;
+    case 'rsa-pss-sha256':
+      jwk.alg = 'PS256';
+      break;
+  }
+
+  jwk.use = 'sig';
+  jwk.kid = 'collective-social-key-1';
+  return jwk;
+}

--- a/src/lib/httpSigning.ts
+++ b/src/lib/httpSigning.ts
@@ -99,7 +99,10 @@ function signWithKey(data: string, config: SigningConfig): Buffer {
 /**
  * Export the public key from a private key as JWK (for CIMD document).
  */
-export function publicKeyToJwk(privateKeyPem: string, algorithm: SigningConfig['algorithm']): crypto.JsonWebKey {
+export function publicKeyToJwk(
+  privateKeyPem: string,
+  algorithm: SigningConfig['algorithm']
+): crypto.JsonWebKey {
   const keyObj = crypto.createPublicKey(privateKeyPem);
   const jwk = keyObj.export({ format: 'jwk' });
 

--- a/src/lib/jwk.ts
+++ b/src/lib/jwk.ts
@@ -4,10 +4,11 @@ import { z } from 'zod';
 
 export type JsonWebKey = Jwk & { kid: string };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const jsonWebKeySchema = z.intersection(
-  jwkValidator as unknown as z.ZodTypeAny,
+  jwkValidator as any,
   z.object({ kid: z.string().nonempty() })
-) as z.ZodType<JsonWebKey>;
+) as unknown as z.ZodType<JsonWebKey>;
 
 const jsonWebKeysSchema = z.array(jsonWebKeySchema).nonempty();
 

--- a/src/lib/jwk.ts
+++ b/src/lib/jwk.ts
@@ -5,9 +5,9 @@ import { z } from 'zod';
 export type JsonWebKey = Jwk & { kid: string };
 
 const jsonWebKeySchema = z.intersection(
-  jwkValidator,
+  jwkValidator as unknown as z.ZodTypeAny,
   z.object({ kid: z.string().nonempty() })
-) satisfies z.ZodType<JsonWebKey>;
+) as z.ZodType<JsonWebKey>;
 
 const jsonWebKeysSchema = z.array(jsonWebKeySchema).nonempty();
 

--- a/src/middleware/trackUserActivity.ts
+++ b/src/middleware/trackUserActivity.ts
@@ -185,10 +185,7 @@ export function createUserActivityTracker(ctx: AppContext) {
             DO UPDATE SET activity_count = user_activity_log.activity_count + 1
           `.execute(ctx.db);
         } catch (activityErr) {
-          ctx.logger.error(
-            { err: activityErr },
-            'Failed to log user activity'
-          );
+          ctx.logger.error({ err: activityErr }, 'Failed to log user activity');
         }
       }
     } catch (err) {

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -522,7 +522,9 @@ migrations['026'] = {
       .createTable('user_activity_log')
       .addColumn('did', 'varchar', (col) => col.notNull())
       .addColumn('activity_date', 'date', (col) => col.notNull())
-      .addColumn('activity_count', 'integer', (col) => col.notNull().defaultTo(1))
+      .addColumn('activity_count', 'integer', (col) =>
+        col.notNull().defaultTo(1)
+      )
       .addUniqueConstraint('user_activity_log_did_date_unique', [
         'did',
         'activity_date',
@@ -583,10 +585,7 @@ migrations['026'] = {
       .dropIndex('feed_events_event_type_idx')
       .ifExists()
       .execute();
-    await db.schema
-      .alterTable('feed_events')
-      .dropColumn('eventType')
-      .execute();
+    await db.schema.alterTable('feed_events').dropColumn('eventType').execute();
     await db.schema.dropTable('bluesky_share_events').ifExists().execute();
     await db.schema.dropTable('user_activity_log').ifExists().execute();
   },
@@ -633,10 +632,7 @@ migrations['027'] = {
   },
 
   async down(db: Kysely<unknown>) {
-    await db.schema
-      .alterTable('share_links')
-      .dropColumn('goalUri')
-      .execute();
+    await db.schema.alterTable('share_links').dropColumn('goalUri').execute();
     await db.schema.dropTable('goals').ifExists().execute();
   },
 };

--- a/src/routes/analytics.ts
+++ b/src/routes/analytics.ts
@@ -97,9 +97,7 @@ export const createRouter = (ctx: AppContext) => {
         });
       } catch (err) {
         ctx.logger.error({ err }, 'Failed to fetch weekly active users');
-        res
-          .status(500)
-          .json({ error: 'Failed to fetch weekly active users' });
+        res.status(500).json({ error: 'Failed to fetch weekly active users' });
       }
     })
   );

--- a/src/routes/collections.ts
+++ b/src/routes/collections.ts
@@ -485,7 +485,8 @@ export const createRouter = (ctx: AppContext) => {
                     record.value.order !== undefined ? record.value.order : 0,
                   mediaType: record.value.mediaType || null,
                   mediaItemId: record.value.mediaItemId || null,
-                  userItemUri: record.value.userItem || useritemData.uri || null,
+                  userItemUri:
+                    record.value.userItem || useritemData.uri || null,
                   // Enriched from useritem
                   status: useritemData.status || null,
                   rating: useritemData.rating ?? null,
@@ -524,7 +525,11 @@ export const createRouter = (ctx: AppContext) => {
                 return item;
               } catch (err) {
                 ctx.logger.warn(
-                  { err, uri: record.uri, mediaItemId: record.value?.mediaItemId },
+                  {
+                    err,
+                    uri: record.uri,
+                    mediaItemId: record.value?.mediaItemId,
+                  },
                   'Failed to enrich collection item, skipping'
                 );
                 return null;
@@ -533,7 +538,9 @@ export const createRouter = (ctx: AppContext) => {
         );
 
         // Filter out any items that failed to load
-        const items = itemResults.filter((item): item is NonNullable<typeof item> => item !== null);
+        const items = itemResults.filter(
+          (item): item is NonNullable<typeof item> => item !== null
+        );
 
         // Sort by order (descending - higher numbers first)
         items.sort((a, b) => (b.order || 0) - (a.order || 0));

--- a/src/routes/completions.ts
+++ b/src/routes/completions.ts
@@ -139,7 +139,9 @@ export const createRouter = (ctx: AppContext) => {
         return res.status(401).json({ error: 'Not authenticated' });
       }
 
-      const completionUri = decodeURIComponent(req.params.completionUri as string);
+      const completionUri = decodeURIComponent(
+        req.params.completionUri as string
+      );
       const rkeyMatch = completionUri.match(/\/([^\/]+)$/);
       if (!rkeyMatch) {
         return res.status(400).json({ error: 'Invalid completion URI' });

--- a/src/routes/goals.ts
+++ b/src/routes/goals.ts
@@ -115,9 +115,7 @@ export const createRouter = (ctx: AppContext) => {
           completedCount: cachedMap.get(g.uri) ?? 0,
           percentage: Math.min(
             100,
-            Math.round(
-              ((cachedMap.get(g.uri) ?? 0) / g.targetCount) * 100
-            )
+            Math.round(((cachedMap.get(g.uri) ?? 0) / g.targetCount) * 100)
           ),
         }));
 
@@ -466,9 +464,7 @@ export const createRouter = (ctx: AppContext) => {
           completedCount: cachedMap.get(g.uri) ?? 0,
           percentage: Math.min(
             100,
-            Math.round(
-              ((cachedMap.get(g.uri) ?? 0) / g.targetCount) * 100
-            )
+            Math.round(((cachedMap.get(g.uri) ?? 0) / g.targetCount) * 100)
           ),
         }));
 

--- a/src/routes/reviewSegments.ts
+++ b/src/routes/reviewSegments.ts
@@ -307,7 +307,9 @@ export const createRouter = (ctx: AppContext) => {
       }
 
       try {
-        const listItemUri = decodeURIComponent(req.params.listItemUri as string);
+        const listItemUri = decodeURIComponent(
+          req.params.listItemUri as string
+        );
 
         // Get all review segments from the user's repo
         const response = await agent.api.com.atproto.repo.listRecords({

--- a/src/routes/share.ts
+++ b/src/routes/share.ts
@@ -261,11 +261,9 @@ export const createRouter = (ctx: AppContext) => {
         !shareType ||
         !['item', 'collection', 'review', 'goal'].includes(shareType)
       ) {
-        return res
-          .status(400)
-          .json({
-            error: 'shareType must be item, collection, review, or goal',
-          });
+        return res.status(400).json({
+          error: 'shareType must be item, collection, review, or goal',
+        });
       }
 
       try {

--- a/src/routes/share.ts
+++ b/src/routes/share.ts
@@ -22,12 +22,16 @@ export const createRouter = (ctx: AppContext) => {
         return res.status(401).json({ error: 'Not authenticated' });
       }
 
-      const { mediaItemId, mediaType, collectionUri, reviewId, goalUri } = req.body;
+      const { mediaItemId, mediaType, collectionUri, reviewId, goalUri } =
+        req.body;
 
       // Validate: must provide either media item, collection, review, or goal, not multiple
-      const providedTypes = [mediaItemId, collectionUri, reviewId, goalUri].filter(
-        Boolean
-      ).length;
+      const providedTypes = [
+        mediaItemId,
+        collectionUri,
+        reviewId,
+        goalUri,
+      ].filter(Boolean).length;
       if (providedTypes === 0) {
         return res.status(400).json({
           error:
@@ -259,7 +263,9 @@ export const createRouter = (ctx: AppContext) => {
       ) {
         return res
           .status(400)
-          .json({ error: 'shareType must be item, collection, review, or goal' });
+          .json({
+            error: 'shareType must be item, collection, review, or goal',
+          });
       }
 
       try {
@@ -431,14 +437,31 @@ export const createRouter = (ctx: AppContext) => {
           // Fetch goal details for Open Graph tags
           const goal = await ctx.db
             .selectFrom('goals')
-            .select(['title', 'mediaType', 'targetCount', 'cachedCompletedCount', 'startDate', 'endDate'])
+            .select([
+              'title',
+              'mediaType',
+              'targetCount',
+              'cachedCompletedCount',
+              'startDate',
+              'endDate',
+            ])
             .where('uri', '=', shareLink.goalUri)
             .executeTakeFirst();
 
           if (goal) {
-            const pct = Math.min(100, Math.round((goal.cachedCompletedCount / goal.targetCount) * 100));
+            const pct = Math.min(
+              100,
+              Math.round((goal.cachedCompletedCount / goal.targetCount) * 100)
+            );
             const mediaLabel = goal.mediaType || 'items';
-            const emoji = goal.mediaType === 'book' ? '📚' : goal.mediaType === 'movie' ? '🎬' : goal.mediaType === 'tv' ? '📺' : '🎯';
+            const emoji =
+              goal.mediaType === 'book'
+                ? '📚'
+                : goal.mediaType === 'movie'
+                  ? '🎬'
+                  : goal.mediaType === 'tv'
+                    ? '📺'
+                    : '🎯';
             title = escapeHtml(`${emoji} ${goal.title}`);
             description = escapeHtml(
               `${goal.cachedCompletedCount} of ${goal.targetCount} ${mediaLabel} completed (${pct}%)`

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -61,7 +61,9 @@ export const createRouter = (ctx: AppContext) => {
     }
 
     try {
-      const handle = Array.isArray(req.params.handle) ? req.params.handle[0] : req.params.handle;
+      const handle = Array.isArray(req.params.handle)
+        ? req.params.handle[0]
+        : req.params.handle;
       const profile = await agent.getProfile({ actor: handle });
 
       // Get collection count

--- a/src/services/opensocial.ts
+++ b/src/services/opensocial.ts
@@ -20,7 +20,8 @@ if (config.openSocialSigningKey) {
   signingConfig = {
     privateKey: config.openSocialSigningKey,
     keyId: config.openSocialKeyId || 'collective-social-key-1',
-    algorithm: (config.openSocialKeyAlgorithm || 'ed25519') as SigningConfig['algorithm'],
+    algorithm: (config.openSocialKeyAlgorithm ||
+      'ed25519') as SigningConfig['algorithm'],
   };
 }
 

--- a/src/services/opensocial.ts
+++ b/src/services/opensocial.ts
@@ -1,14 +1,28 @@
 /**
  * OpenSocial API client for Collective Social.
  *
- * Uses an API key registered through the OpenSocial developer UI
- * (stored in OPENSOCIAL_API_KEY env var) to talk to the OpenSocial backend.
+ * Supports two authentication modes:
+ * - API key (X-Api-Key header) — legacy, used when OPENSOCIAL_API_KEY is set
+ * - CIMD + HTTP Message Signatures — used when OPENSOCIAL_SIGNING_KEY is set
+ *
+ * When both are configured, HTTP Message Signatures take priority.
  */
 
 import { config } from '../config';
+import { signRequest, type SigningConfig } from '../lib/httpSigning';
 
 const OPENSOCIAL_API_URL = config.openSocialApiUrl;
 const OPENSOCIAL_API_KEY = config.openSocialApiKey;
+
+// Build signing config from env if available
+let signingConfig: SigningConfig | null = null;
+if (config.openSocialSigningKey) {
+  signingConfig = {
+    privateKey: config.openSocialSigningKey,
+    keyId: config.openSocialKeyId || 'collective-social-key-1',
+    algorithm: (config.openSocialKeyAlgorithm || 'ed25519') as SigningConfig['algorithm'],
+  };
+}
 
 interface Community {
   did: string;
@@ -65,21 +79,39 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
       500
     );
   }
-  if (!OPENSOCIAL_API_KEY) {
+  if (!signingConfig && !OPENSOCIAL_API_KEY) {
     throw new OpenSocialClientError(
-      'OPENSOCIAL_API_KEY is not configured',
+      'Neither OPENSOCIAL_SIGNING_KEY nor OPENSOCIAL_API_KEY is configured',
       500
     );
   }
 
   const url = `${OPENSOCIAL_API_URL}${path}`;
+  const body = options.body as string | undefined;
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...(options.headers as Record<string, string>),
+  };
+
+  // Prefer HTTP Message Signatures when signing key is configured
+  if (signingConfig) {
+    const sigHeaders = signRequest(
+      {
+        method: options.method || 'GET',
+        url,
+        headers,
+        body,
+      },
+      signingConfig
+    );
+    Object.assign(headers, sigHeaders);
+  } else {
+    headers['X-Api-Key'] = OPENSOCIAL_API_KEY;
+  }
+
   const response = await fetch(url, {
     ...options,
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Api-Key': OPENSOCIAL_API_KEY,
-      ...options.headers,
-    },
+    headers,
   });
 
   if (!response.ok) {

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,4 +1,3 @@
 // Express v5 types params as `string | string[]` to account for wildcard routes.
 // This project only uses named params (e.g., /:id), which are always strings.
 // We provide a helper type and recommend `as string` casts at usage sites.
-

--- a/test/httpSigning.test.ts
+++ b/test/httpSigning.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest';
+import crypto from 'crypto';
+import { signRequest, publicKeyToJwk, type SigningConfig } from '../src/lib/httpSigning';
+
+// Generate test key pairs for each algorithm
+function generateEd25519Key() {
+  const { privateKey } = crypto.generateKeyPairSync('ed25519');
+  return privateKey.export({ type: 'pkcs8', format: 'pem' }) as string;
+}
+
+function generateEcdsaP256Key() {
+  const { privateKey } = crypto.generateKeyPairSync('ec', { namedCurve: 'P-256' });
+  return privateKey.export({ type: 'pkcs8', format: 'pem' }) as string;
+}
+
+function generateRsaKey() {
+  const { privateKey } = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
+  return privateKey.export({ type: 'pkcs8', format: 'pem' }) as string;
+}
+
+describe('httpSigning', () => {
+  describe('signRequest', () => {
+    it('produces Signature-Input and Signature headers (Ed25519)', () => {
+      const config: SigningConfig = {
+        privateKey: generateEd25519Key(),
+        keyId: 'test-key',
+        algorithm: 'ed25519',
+      };
+
+      const result = signRequest(
+        { method: 'GET', url: 'https://example.com/api/v1/communities', headers: {} },
+        config
+      );
+
+      expect(result['Signature-Input']).toMatch(/^sig1=\("@method" "@path"\);created=\d+;keyid="test-key"$/);
+      expect(result['Signature']).toMatch(/^sig1=:[A-Za-z0-9+/]+=*:$/);
+      expect(result['Content-Digest']).toBeUndefined();
+    });
+
+    it('includes Content-Digest for requests with body', () => {
+      const config: SigningConfig = {
+        privateKey: generateEd25519Key(),
+        keyId: 'test-key',
+        algorithm: 'ed25519',
+      };
+
+      const body = JSON.stringify({ user_did: 'did:plc:test' });
+      const result = signRequest(
+        { method: 'POST', url: 'https://example.com/api/v1/communities', headers: {}, body },
+        config
+      );
+
+      expect(result['Content-Digest']).toMatch(/^sha-256=:[A-Za-z0-9+/]+=*:$/);
+      expect(result['Signature-Input']).toContain('"content-digest"');
+    });
+
+    it('signature is verifiable with the public key (Ed25519)', () => {
+      const pem = generateEd25519Key();
+      const config: SigningConfig = { privateKey: pem, keyId: 'test-key', algorithm: 'ed25519' };
+
+      const url = 'https://example.com/api/v1/test';
+      const result = signRequest({ method: 'GET', url, headers: {} }, config);
+
+      // Extract and reconstruct signature base
+      const sigInput = result['Signature-Input'].replace('sig1=', '');
+      const parsedUrl = new URL(url);
+      const signatureBase = `"@method": GET\n"@path": ${parsedUrl.pathname}\n"@signature-params": ${sigInput}`;
+
+      // Extract raw signature
+      const sigMatch = result['Signature'].match(/^sig1=:(.+):$/);
+      const sigBytes = Buffer.from(sigMatch![1], 'base64');
+
+      // Verify with public key
+      const publicKey = crypto.createPublicKey(pem);
+      const valid = crypto.verify(null, Buffer.from(signatureBase), publicKey, sigBytes);
+      expect(valid).toBe(true);
+    });
+
+    it('signature is verifiable with the public key (ECDSA P-256)', () => {
+      const pem = generateEcdsaP256Key();
+      const config: SigningConfig = { privateKey: pem, keyId: 'test-key', algorithm: 'ecdsa-p256' };
+
+      const url = 'https://example.com/api/v1/test';
+      const result = signRequest({ method: 'GET', url, headers: {} }, config);
+
+      const sigInput = result['Signature-Input'].replace('sig1=', '');
+      const parsedUrl = new URL(url);
+      const signatureBase = `"@method": GET\n"@path": ${parsedUrl.pathname}\n"@signature-params": ${sigInput}`;
+
+      const sigMatch = result['Signature'].match(/^sig1=:(.+):$/);
+      const sigBytes = Buffer.from(sigMatch![1], 'base64');
+
+      const publicKey = crypto.createPublicKey(pem);
+      const valid = crypto.createVerify('SHA256').update(signatureBase).verify(publicKey, sigBytes);
+      expect(valid).toBe(true);
+    });
+
+    it('signature is verifiable with the public key (RSA-PSS)', () => {
+      const pem = generateRsaKey();
+      const config: SigningConfig = { privateKey: pem, keyId: 'test-key', algorithm: 'rsa-pss-sha256' };
+
+      const url = 'https://example.com/api/v1/test';
+      const body = '{"test":true}';
+      const result = signRequest({ method: 'POST', url, headers: {}, body }, config);
+
+      const sigInput = result['Signature-Input'].replace('sig1=', '');
+      const parsedUrl = new URL(url);
+      const signatureBase = `"@method": POST\n"@path": ${parsedUrl.pathname}\n"content-digest": ${result['Content-Digest']}\n"@signature-params": ${sigInput}`;
+
+      const sigMatch = result['Signature'].match(/^sig1=:(.+):$/);
+      const sigBytes = Buffer.from(sigMatch![1], 'base64');
+
+      const publicKey = crypto.createPublicKey(pem);
+      const valid = crypto.createVerify('SHA256').update(signatureBase).verify(
+        { key: publicKey, padding: crypto.constants.RSA_PKCS1_PSS_PADDING, saltLength: crypto.constants.RSA_PSS_SALTLEN_DIGEST },
+        sigBytes
+      );
+      expect(valid).toBe(true);
+    });
+
+    it('different requests produce different signatures', () => {
+      const config: SigningConfig = {
+        privateKey: generateEd25519Key(),
+        keyId: 'test-key',
+        algorithm: 'ed25519',
+      };
+
+      const r1 = signRequest(
+        { method: 'GET', url: 'https://example.com/api/v1/a', headers: {} },
+        config
+      );
+      const r2 = signRequest(
+        { method: 'GET', url: 'https://example.com/api/v1/b', headers: {} },
+        config
+      );
+
+      expect(r1['Signature']).not.toBe(r2['Signature']);
+    });
+  });
+
+  describe('publicKeyToJwk', () => {
+    it('exports Ed25519 public key as JWK', () => {
+      const pem = generateEd25519Key();
+      const jwk = publicKeyToJwk(pem, 'ed25519');
+
+      expect(jwk.kty).toBe('OKP');
+      expect(jwk.crv).toBe('Ed25519');
+      expect(jwk.alg).toBe('EdDSA');
+      expect(jwk.use).toBe('sig');
+      expect(jwk.kid).toBe('collective-social-key-1');
+      // Should not contain private key material
+      expect(jwk.d).toBeUndefined();
+    });
+
+    it('exports ECDSA P-256 public key as JWK', () => {
+      const pem = generateEcdsaP256Key();
+      const jwk = publicKeyToJwk(pem, 'ecdsa-p256');
+
+      expect(jwk.kty).toBe('EC');
+      expect(jwk.crv).toBe('P-256');
+      expect(jwk.alg).toBe('ES256');
+      expect(jwk.d).toBeUndefined();
+    });
+
+    it('exports RSA public key as JWK', () => {
+      const pem = generateRsaKey();
+      const jwk = publicKeyToJwk(pem, 'rsa-pss-sha256');
+
+      expect(jwk.kty).toBe('RSA');
+      expect(jwk.alg).toBe('PS256');
+      expect(jwk.d).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements the client side of CIMD + HTTP Message Signatures auth for the Open Social API, complementing the server-side implementation in open-social PR #73.

### How It Works

**Before:** All requests to opensocial.community used `X-Api-Key` header authentication.

**After:** When `OPENSOCIAL_SIGNING_KEY` is configured, requests are signed with HTTP Message Signatures (RFC 9421). The API key path remains as a fallback.

### Architecture

```
Collective Social API                          Open Social API
┌─────────────────────┐                   ┌──────────────────────┐
│ opensocial.ts       │                   │ middleware/auth.ts    │
│ signRequest()       │ ──signed req──▶   │ verifySignature()    │
│                     │                   │                      │
│ /.well-known/       │ ◀──fetch key──    │ fetchCimdDocument()  │
│ client-metadata.json│                   │                      │
└─────────────────────┘                   └──────────────────────┘
```

1. Collective generates a key pair (e.g., `openssl genpkey -algorithm ed25519`)
2. Private key goes in `OPENSOCIAL_SIGNING_KEY` env var
3. Public key is served at `/.well-known/client-metadata.json` (CIMD document)
4. Every request to Open Social gets signed with `Signature-Input` + `Signature` headers
5. Open Social fetches the CIMD document, extracts the public key, verifies the signature

### New Files

| File | Purpose |
|------|---------|
| `src/lib/httpSigning.ts` | RFC 9421 request signing + JWK export |
| `test/httpSigning.test.ts` | 9 tests: signing/verification for Ed25519, ECDSA, RSA-PSS |

### Changed Files

| File | Change |
|------|--------|
| `src/services/opensocial.ts` | Dual auth: HTTP sig preferred, API key fallback |
| `src/config.ts` | New config: `openSocialSigningKey`, `openSocialKeyId`, `openSocialKeyAlgorithm` |
| `src/index.ts` | `/.well-known/client-metadata.json` endpoint |
| `.env.example` | Documentation for new env vars |

### Supported Algorithms

- **Ed25519** (recommended) — fastest, smallest keys
- **ECDSA P-256** — widely supported
- **RSA-PSS SHA-256** — legacy compatibility

### Testing

- 9 new tests covering all three signing algorithms + verification + JWK export
- All 31 tests passing

Closes #46