### PR TITLE
Phase 1: Auth migration + group bug fixes

### DIFF
--- a/src/auth/client.ts
+++ b/src/auth/client.ts
@@ -10,6 +10,7 @@ import assert from 'node:assert';
 import type { Database } from '../db';
 import { config } from '../config';
 import { SessionStore, StateStore } from './storage';
+import { COLLECTIVE_SCOPES } from './scopes';
 
 export async function createOAuthClient(db: Database) {
   // Confidential client require a keyset accessible on the internet. Non
@@ -42,7 +43,7 @@ export async function createOAuthClient(db: Database) {
         client_id: `${config.serviceUrl}/oauth-client-metadata.json`,
         jwks_uri: `${config.serviceUrl}/.well-known/jwks.json`,
         redirect_uris: [`${config.serviceUrl}/oauth/callback`],
-        scope: 'atproto transition:generic',
+        scope: COLLECTIVE_SCOPES,
         grant_types: ['authorization_code', 'refresh_token'],
         response_types: ['code'],
         application_type: 'web',
@@ -53,7 +54,7 @@ export async function createOAuthClient(db: Database) {
     : atprotoLoopbackClientMetadata(
         `http://localhost?${new URLSearchParams([
           ['redirect_uri', `http://127.0.0.1:${config.port}/oauth/callback`],
-          ['scope', `atproto transition:generic`],
+          ['scope', COLLECTIVE_SCOPES],
         ])}`
       );
 
@@ -63,6 +64,8 @@ export async function createOAuthClient(db: Database) {
     stateStore: new StateStore(db),
     sessionStore: new SessionStore(db),
     plcDirectoryUrl: config.plcUrl,
-    handleResolver: config.pdsUrl,
+    // No handleResolver override — default AtprotoHandleResolverNode resolves
+    // handles via DNS TXT records and HTTP well-known, supporting any PDS.
+    allowHttp: config.nodeEnv === 'development',
   });
 }

--- a/src/auth/scopes.ts
+++ b/src/auth/scopes.ts
@@ -1,0 +1,13 @@
+/**
+ * OAuth scope string for Collective Social.
+ *
+ * Lists the 10 user-PDS collections that the OAuth client requests write
+ * access to. Group-PDS collections are excluded because those writes are
+ * proxied through the OpenSocial service using its own service credentials,
+ * not the user's OAuth token.
+ *
+ * Decided: 2026-05-08 by Simon — see
+ * .squad/decisions/inbox/simon-nsid-scopes.md
+ */
+export const COLLECTIVE_SCOPES =
+  'atproto repo:app.collectivesocial.feed.list repo:app.collectivesocial.feed.listitem repo:app.collectivesocial.feed.useritem repo:app.collectivesocial.feed.review repo:app.collectivesocial.feed.completion repo:app.collectivesocial.feed.comment repo:app.collectivesocial.feed.react repo:app.collectivesocial.feed.reviewsegment repo:app.collectivesocial.feed.goal repo:app.collectivesocial.feed.grouppost';

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,9 @@ app.use(
   cors({
     origin:
       config.nodeEnv === 'production'
-        ? (config.corsOrigin ? [config.corsOrigin] : [])
+        ? config.corsOrigin
+          ? [config.corsOrigin]
+          : []
         : ['http://127.0.0.1:5173', 'http://localhost:5173'],
     credentials: true,
   })
@@ -76,21 +78,25 @@ app.use((req, _res, next) => {
         const collection = decodeURIComponent(segments[1]);
         const rkey = decodeURIComponent(segments[2]);
         const atUri = `at://${did}/${collection}/${rkey}`;
-        const suffix = segments.length > 3 ? '/' + segments.slice(3).join('/') : '';
+        const suffix =
+          segments.length > 3 ? '/' + segments.slice(3).join('/') : '';
 
         // Recursively handle a second AT URI in the suffix (e.g. /items/:itemUri)
         let processedSuffix = suffix;
         const innerMatch = suffix.match(/\/at(?:%3A|:)\/{1,2}/i);
         if (innerMatch && innerMatch.index !== undefined) {
           const sPre = suffix.substring(0, innerMatch.index + 1);
-          const sAfterAt = suffix.substring(innerMatch.index + innerMatch[0].length);
+          const sAfterAt = suffix.substring(
+            innerMatch.index + innerMatch[0].length
+          );
           const innerSegs = sAfterAt.split('/');
           if (innerSegs.length >= 3) {
             const iDid = decodeURIComponent(innerSegs[0]);
             const iCol = decodeURIComponent(innerSegs[1]);
             const iRkey = decodeURIComponent(innerSegs[2]);
             const innerAtUri = `at://${iDid}/${iCol}/${iRkey}`;
-            const iSuffix = innerSegs.length > 3 ? '/' + innerSegs.slice(3).join('/') : '';
+            const iSuffix =
+              innerSegs.length > 3 ? '/' + innerSegs.slice(3).join('/') : '';
             processedSuffix = sPre + encodeURIComponent(innerAtUri) + iSuffix;
           }
         }

--- a/src/middleware/trackUserActivity.ts
+++ b/src/middleware/trackUserActivity.ts
@@ -185,10 +185,7 @@ export function createUserActivityTracker(ctx: AppContext) {
             DO UPDATE SET activity_count = user_activity_log.activity_count + 1
           `.execute(ctx.db);
         } catch (activityErr) {
-          ctx.logger.error(
-            { err: activityErr },
-            'Failed to log user activity'
-          );
+          ctx.logger.error({ err: activityErr }, 'Failed to log user activity');
         }
       }
     } catch (err) {

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -522,7 +522,9 @@ migrations['026'] = {
       .createTable('user_activity_log')
       .addColumn('did', 'varchar', (col) => col.notNull())
       .addColumn('activity_date', 'date', (col) => col.notNull())
-      .addColumn('activity_count', 'integer', (col) => col.notNull().defaultTo(1))
+      .addColumn('activity_count', 'integer', (col) =>
+        col.notNull().defaultTo(1)
+      )
       .addUniqueConstraint('user_activity_log_did_date_unique', [
         'did',
         'activity_date',
@@ -583,10 +585,7 @@ migrations['026'] = {
       .dropIndex('feed_events_event_type_idx')
       .ifExists()
       .execute();
-    await db.schema
-      .alterTable('feed_events')
-      .dropColumn('eventType')
-      .execute();
+    await db.schema.alterTable('feed_events').dropColumn('eventType').execute();
     await db.schema.dropTable('bluesky_share_events').ifExists().execute();
     await db.schema.dropTable('user_activity_log').ifExists().execute();
   },
@@ -633,10 +632,7 @@ migrations['027'] = {
   },
 
   async down(db: Kysely<unknown>) {
-    await db.schema
-      .alterTable('share_links')
-      .dropColumn('goalUri')
-      .execute();
+    await db.schema.alterTable('share_links').dropColumn('goalUri').execute();
     await db.schema.dropTable('goals').ifExists().execute();
   },
 };

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,34 +1,8 @@
 import express, { Request, Response } from 'express';
-import { getIronSession } from 'iron-session';
 import type { AppContext } from '../context';
-import { config } from '../config';
 import { handler } from '../lib/http';
-import { Agent } from '@atproto/api';
 import { fetchUserHandles } from '../lib/users';
-
-type Session = { did?: string };
-
-// Helper function to get the authenticated user's session
-async function getSessionAgent(
-  req: express.Request,
-  res: express.Response,
-  ctx: AppContext
-) {
-  res.setHeader('Vary', 'Cookie');
-
-  const session = await getIronSession<Session>(req, res, {
-    cookieName: 'sid',
-    password: config.cookieSecret,
-    cookieOptions: {
-      secure: config.nodeEnv === 'production',
-      sameSite: 'lax',
-      httpOnly: true,
-      path: '/',
-    },
-  });
-
-  return session.did || null;
-}
+import { getSessionAgent } from '../auth/agent';
 
 // Middleware to check if user is admin
 async function requireAdmin(
@@ -36,9 +10,9 @@ async function requireAdmin(
   res: express.Response,
   ctx: AppContext
 ): Promise<boolean> {
-  const did = await getSessionAgent(req, res, ctx);
+  const agent = await getSessionAgent(req, res, ctx);
 
-  if (!did) {
+  if (!agent?.did) {
     res.status(401).json({ error: 'Not authenticated' });
     return false;
   }
@@ -46,7 +20,7 @@ async function requireAdmin(
   const user = await ctx.db
     .selectFrom('users')
     .select(['isAdmin'])
-    .where('did', '=', did)
+    .where('did', '=', agent.did)
     .executeTakeFirst();
 
   if (!user?.isAdmin) {
@@ -94,23 +68,18 @@ export const createRouter = (ctx: AppContext) => {
           .execute();
 
         // Get admin agent for fetching user handles
-        const sessionDid = await getSessionAgent(req, res, ctx);
+        const adminAgent = await getSessionAgent(req, res, ctx);
         let userHandles = new Map<string, string>();
 
-        if (sessionDid) {
+        if (adminAgent) {
           try {
-            const oauthSession = await ctx.oauthClient.restore(sessionDid);
-            if (oauthSession) {
-              const adminAgent = new Agent(oauthSession);
-
-              // Fetch user handles
-              const userDids = users.map((user) => user.did);
-              userHandles = await fetchUserHandles(
-                adminAgent,
-                userDids,
-                ctx.logger
-              );
-            }
+            // Fetch user handles
+            const userDids = users.map((user) => user.did);
+            userHandles = await fetchUserHandles(
+              adminAgent,
+              userDids,
+              ctx.logger
+            );
           } catch (err) {
             ctx.logger.error(
               { err },
@@ -272,27 +241,20 @@ export const createRouter = (ctx: AppContext) => {
         const origin = req.get('origin') || 'http://127.0.0.1:5173';
 
         // Get admin agent for fetching user handles and collection names
-        const sessionDid = await getSessionAgent(req, res, ctx);
+        const adminAgentForCollections = await getSessionAgent(req, res, ctx);
         let userHandles = new Map<string, string>();
-        let adminAgentForCollections: Agent | null = null;
 
-        if (sessionDid) {
+        if (adminAgentForCollections) {
           try {
-            const oauthSession = await ctx.oauthClient.restore(sessionDid);
-            if (oauthSession) {
-              const adminAgent = new Agent(oauthSession);
-              adminAgentForCollections = adminAgent;
-
-              // Fetch user handles
-              const uniqueUserDids = [
-                ...new Set(shareLinks.map((link) => link.userDid)),
-              ];
-              userHandles = await fetchUserHandles(
-                adminAgent,
-                uniqueUserDids,
-                ctx.logger
-              );
-            }
+            // Fetch user handles
+            const uniqueUserDids = [
+              ...new Set(shareLinks.map((link) => link.userDid)),
+            ];
+            userHandles = await fetchUserHandles(
+              adminAgentForCollections,
+              uniqueUserDids,
+              ctx.logger
+            );
           } catch (err) {
             ctx.logger.error(
               { err },
@@ -425,16 +387,16 @@ export const createRouter = (ctx: AppContext) => {
     handler(async (req: Request, res: Response) => {
       res.setHeader('cache-control', 'no-store');
 
-      const did = await getSessionAgent(req, res, ctx);
+      const agent = await getSessionAgent(req, res, ctx);
 
-      if (!did) {
+      if (!agent?.did) {
         return res.json({ isAdmin: false });
       }
 
       const user = await ctx.db
         .selectFrom('users')
         .select(['isAdmin'])
-        .where('did', '=', did)
+        .where('did', '=', agent.did)
         .executeTakeFirst();
 
       res.json({ isAdmin: user?.isAdmin || false });

--- a/src/routes/analytics.ts
+++ b/src/routes/analytics.ts
@@ -86,9 +86,7 @@ export const createRouter = (ctx: AppContext) => {
         });
       } catch (err) {
         ctx.logger.error({ err }, 'Failed to fetch weekly active users');
-        res
-          .status(500)
-          .json({ error: 'Failed to fetch weekly active users' });
+        res.status(500).json({ error: 'Failed to fetch weekly active users' });
       }
     })
   );

--- a/src/routes/analytics.ts
+++ b/src/routes/analytics.ts
@@ -2,10 +2,8 @@ import express, { Request, Response } from 'express';
 import { getIronSession } from 'iron-session';
 import { sql } from 'kysely';
 import type { AppContext } from '../context';
-import { config } from '../config';
 import { handler } from '../lib/http';
-
-type Session = { did?: string };
+import { SESSION_OPTIONS, Session } from '../auth/session';
 
 async function requireAdmin(
   req: express.Request,
@@ -13,16 +11,7 @@ async function requireAdmin(
   ctx: AppContext
 ): Promise<boolean> {
   res.setHeader('Vary', 'Cookie');
-  const session = await getIronSession<Session>(req, res, {
-    cookieName: 'sid',
-    password: config.cookieSecret,
-    cookieOptions: {
-      secure: config.nodeEnv === 'production',
-      sameSite: 'lax',
-      httpOnly: true,
-      path: '/',
-    },
-  });
+  const session = await getIronSession<Session>(req, res, SESSION_OPTIONS);
   if (!session.did) {
     res.status(401).json({ error: 'Not authenticated' });
     return false;

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -74,7 +74,11 @@ export const createRouter = (ctx: AppContext): RequestListener => {
       const params = new URLSearchParams(req.originalUrl.split('?')[1]);
       try {
         // Load the session cookie
-        const session = await getIronSession<Session>(req, res, SESSION_OPTIONS);
+        const session = await getIronSession<Session>(
+          req,
+          res,
+          SESSION_OPTIONS
+        );
 
         // If the user is already signed in, destroy the old credentials
         if (session.did) {

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -11,6 +11,7 @@ import { config } from '../config';
 import { handler } from '../lib/http';
 import { ifString } from '../lib/stringUtil';
 import { SESSION_OPTIONS, Session } from '../auth/session';
+import { COLLECTIVE_SCOPES } from '../auth/scopes';
 
 // Max age, in seconds, for static routes and assets
 const MAX_AGE = config.nodeEnv === 'production' ? 60 : 300;
@@ -73,16 +74,7 @@ export const createRouter = (ctx: AppContext): RequestListener => {
       const params = new URLSearchParams(req.originalUrl.split('?')[1]);
       try {
         // Load the session cookie
-        const session = await getIronSession<Session>(req, res, {
-          cookieName: 'sid',
-          password: config.cookieSecret,
-          cookieOptions: {
-            secure: config.nodeEnv === 'production',
-            sameSite: 'lax',
-            httpOnly: true,
-            path: '/',
-          },
-        });
+        const session = await getIronSession<Session>(req, res, SESSION_OPTIONS);
 
         // If the user is already signed in, destroy the old credentials
         if (session.did) {
@@ -129,7 +121,7 @@ export const createRouter = (ctx: AppContext): RequestListener => {
 
         // Initiate the OAuth flow
         const url = await ctx.oauthClient.authorize(input, {
-          scope: 'atproto transition:generic',
+          scope: COLLECTIVE_SCOPES,
         });
 
         res.redirect(url.toString());
@@ -152,7 +144,7 @@ export const createRouter = (ctx: AppContext): RequestListener => {
       try {
         const service = config.pdsUrl;
         const url = await ctx.oauthClient.authorize(service, {
-          scope: 'atproto transition:generic',
+          scope: COLLECTIVE_SCOPES,
         });
         res.redirect(url.toString());
       } catch (err) {
@@ -174,16 +166,7 @@ export const createRouter = (ctx: AppContext): RequestListener => {
       // Never store this route
       res.setHeader('cache-control', 'no-store');
 
-      const session = await getIronSession<Session>(req, res, {
-        cookieName: 'sid',
-        password: config.cookieSecret,
-        cookieOptions: {
-          secure: config.nodeEnv === 'production',
-          sameSite: 'lax',
-          httpOnly: true,
-          path: '/',
-        },
-      });
+      const session = await getIronSession<Session>(req, res, SESSION_OPTIONS);
 
       // Revoke credentials on the server
       if (session.did) {

--- a/src/routes/collections.ts
+++ b/src/routes/collections.ts
@@ -485,7 +485,8 @@ export const createRouter = (ctx: AppContext) => {
                     record.value.order !== undefined ? record.value.order : 0,
                   mediaType: record.value.mediaType || null,
                   mediaItemId: record.value.mediaItemId || null,
-                  userItemUri: record.value.userItem || useritemData.uri || null,
+                  userItemUri:
+                    record.value.userItem || useritemData.uri || null,
                   // Enriched from useritem
                   status: useritemData.status || null,
                   rating: useritemData.rating ?? null,
@@ -524,7 +525,11 @@ export const createRouter = (ctx: AppContext) => {
                 return item;
               } catch (err) {
                 ctx.logger.warn(
-                  { err, uri: record.uri, mediaItemId: record.value?.mediaItemId },
+                  {
+                    err,
+                    uri: record.uri,
+                    mediaItemId: record.value?.mediaItemId,
+                  },
                   'Failed to enrich collection item, skipping'
                 );
                 return null;
@@ -533,7 +538,9 @@ export const createRouter = (ctx: AppContext) => {
         );
 
         // Filter out any items that failed to load
-        const items = itemResults.filter((item): item is NonNullable<typeof item> => item !== null);
+        const items = itemResults.filter(
+          (item): item is NonNullable<typeof item> => item !== null
+        );
 
         // Sort by order (descending - higher numbers first)
         items.sort((a, b) => (b.order || 0) - (a.order || 0));

--- a/src/routes/completions.ts
+++ b/src/routes/completions.ts
@@ -139,7 +139,9 @@ export const createRouter = (ctx: AppContext) => {
         return res.status(401).json({ error: 'Not authenticated' });
       }
 
-      const completionUri = decodeURIComponent(req.params.completionUri as string);
+      const completionUri = decodeURIComponent(
+        req.params.completionUri as string
+      );
       const rkeyMatch = completionUri.match(/\/([^\/]+)$/);
       if (!rkeyMatch) {
         return res.status(400).json({ error: 'Invalid completion URI' });

--- a/src/routes/goals.ts
+++ b/src/routes/goals.ts
@@ -115,9 +115,7 @@ export const createRouter = (ctx: AppContext) => {
           completedCount: cachedMap.get(g.uri) ?? 0,
           percentage: Math.min(
             100,
-            Math.round(
-              ((cachedMap.get(g.uri) ?? 0) / g.targetCount) * 100
-            )
+            Math.round(((cachedMap.get(g.uri) ?? 0) / g.targetCount) * 100)
           ),
         }));
 
@@ -466,9 +464,7 @@ export const createRouter = (ctx: AppContext) => {
           completedCount: cachedMap.get(g.uri) ?? 0,
           percentage: Math.min(
             100,
-            Math.round(
-              ((cachedMap.get(g.uri) ?? 0) / g.targetCount) * 100
-            )
+            Math.round(((cachedMap.get(g.uri) ?? 0) / g.targetCount) * 100)
           ),
         }));
 

--- a/src/routes/groupContent.ts
+++ b/src/routes/groupContent.ts
@@ -13,7 +13,11 @@
 import express, { Response } from 'express';
 import type { AppContext } from '../context';
 import { handler } from '../lib/http';
-import { requireGroupMember, requireGroupAdmin, GroupAuthRequest } from '../middleware/groupAuth';
+import {
+  requireGroupMember,
+  requireGroupAdmin,
+  GroupAuthRequest,
+} from '../middleware/groupAuth';
 import * as opensocial from '../services/opensocial';
 import { rkeyFromUri } from '../services/opensocial';
 import type { PdsRecord } from '../services/opensocial';

--- a/src/routes/groupContent.ts
+++ b/src/routes/groupContent.ts
@@ -13,7 +13,7 @@
 import express, { Response } from 'express';
 import type { AppContext } from '../context';
 import { handler } from '../lib/http';
-import { requireGroupMember, GroupAuthRequest } from '../middleware/groupAuth';
+import { requireGroupMember, requireGroupAdmin, GroupAuthRequest } from '../middleware/groupAuth';
 import * as opensocial from '../services/opensocial';
 import { rkeyFromUri } from '../services/opensocial';
 import type { PdsRecord } from '../services/opensocial';
@@ -43,6 +43,7 @@ export const createRouter = (ctx: AppContext) => {
   // Fine-grained permission enforcement (member vs admin per collection)
   // is handled by open-social when the record write is proxied.
   const memberOnly = requireGroupMember(ctx);
+  const adminOnly = requireGroupAdmin(ctx);
 
   // ═══════════════════════════════════════════════════════════════
   // LISTS
@@ -422,13 +423,13 @@ export const createRouter = (ctx: AppContext) => {
 
   /**
    * PUT /groups/:communityDid/items/:rkey/status
-   * Set the group status of a list item. Admin only.
+   * Admin only — sets the GROUP's shared status for a list item.
    *
    * Body: { status: 'not-started' | 'in-progress' | 'completed' }
    */
   router.put(
     '/items/:rkey/status',
-    memberOnly,
+    adminOnly,
     handler(async (req: GroupAuthRequest, res: Response) => {
       const { userDid, communityDid } = req.groupAuth!;
       const rkey = req.params.rkey as string;
@@ -1012,6 +1013,7 @@ export const createRouter = (ctx: AppContext) => {
             memberDid: userDid,
             completed: true,
             completedAt: now,
+            createdAt: now,
           }
         );
       } catch (err: any) {

--- a/src/routes/reviewSegments.ts
+++ b/src/routes/reviewSegments.ts
@@ -307,7 +307,9 @@ export const createRouter = (ctx: AppContext) => {
       }
 
       try {
-        const listItemUri = decodeURIComponent(req.params.listItemUri as string);
+        const listItemUri = decodeURIComponent(
+          req.params.listItemUri as string
+        );
 
         // Get all review segments from the user's repo
         const response = await agent.api.com.atproto.repo.listRecords({

--- a/src/routes/share.ts
+++ b/src/routes/share.ts
@@ -22,12 +22,16 @@ export const createRouter = (ctx: AppContext) => {
         return res.status(401).json({ error: 'Not authenticated' });
       }
 
-      const { mediaItemId, mediaType, collectionUri, reviewId, goalUri } = req.body;
+      const { mediaItemId, mediaType, collectionUri, reviewId, goalUri } =
+        req.body;
 
       // Validate: must provide either media item, collection, review, or goal, not multiple
-      const providedTypes = [mediaItemId, collectionUri, reviewId, goalUri].filter(
-        Boolean
-      ).length;
+      const providedTypes = [
+        mediaItemId,
+        collectionUri,
+        reviewId,
+        goalUri,
+      ].filter(Boolean).length;
       if (providedTypes === 0) {
         return res.status(400).json({
           error:
@@ -257,9 +261,9 @@ export const createRouter = (ctx: AppContext) => {
         !shareType ||
         !['item', 'collection', 'review', 'goal'].includes(shareType)
       ) {
-        return res
-          .status(400)
-          .json({ error: 'shareType must be item, collection, review, or goal' });
+        return res.status(400).json({
+          error: 'shareType must be item, collection, review, or goal',
+        });
       }
 
       try {
@@ -431,14 +435,31 @@ export const createRouter = (ctx: AppContext) => {
           // Fetch goal details for Open Graph tags
           const goal = await ctx.db
             .selectFrom('goals')
-            .select(['title', 'mediaType', 'targetCount', 'cachedCompletedCount', 'startDate', 'endDate'])
+            .select([
+              'title',
+              'mediaType',
+              'targetCount',
+              'cachedCompletedCount',
+              'startDate',
+              'endDate',
+            ])
             .where('uri', '=', shareLink.goalUri)
             .executeTakeFirst();
 
           if (goal) {
-            const pct = Math.min(100, Math.round((goal.cachedCompletedCount / goal.targetCount) * 100));
+            const pct = Math.min(
+              100,
+              Math.round((goal.cachedCompletedCount / goal.targetCount) * 100)
+            );
             const mediaLabel = goal.mediaType || 'items';
-            const emoji = goal.mediaType === 'book' ? '📚' : goal.mediaType === 'movie' ? '🎬' : goal.mediaType === 'tv' ? '📺' : '🎯';
+            const emoji =
+              goal.mediaType === 'book'
+                ? '📚'
+                : goal.mediaType === 'movie'
+                  ? '🎬'
+                  : goal.mediaType === 'tv'
+                    ? '📺'
+                    : '🎯';
             title = escapeHtml(`${emoji} ${goal.title}`);
             description = escapeHtml(
               `${goal.cachedCompletedCount} of ${goal.targetCount} ${mediaLabel} completed (${pct}%)`

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -61,7 +61,9 @@ export const createRouter = (ctx: AppContext) => {
     }
 
     try {
-      const handle = Array.isArray(req.params.handle) ? req.params.handle[0] : req.params.handle;
+      const handle = Array.isArray(req.params.handle)
+        ? req.params.handle[0]
+        : req.params.handle;
       const profile = await agent.getProfile({ actor: handle });
 
       // Get collection count

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,4 +1,3 @@
 // Express v5 types params as `string | string[]` to account for wildcard routes.
 // This project only uses named params (e.g., /:id), which are always strings.
 // We provide a helper type and recommend `as string` casts at usage sites.
-

--- a/test/groupAuth.test.ts
+++ b/test/groupAuth.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Response, NextFunction } from 'express';
+import { requireGroupMember, requireGroupAdmin, type GroupAuthRequest } from '../src/middleware/groupAuth';
+
+// Mock the entire opensocial service so no real HTTP calls are made.
+vi.mock('../src/services/opensocial', () => ({
+  checkMembership: vi.fn(),
+}));
+
+// Mock getSessionAgent so tests don't need a real database / cookie session.
+vi.mock('../src/auth/agent', () => ({
+  getSessionAgent: vi.fn(),
+}));
+
+import * as opensocial from '../src/services/opensocial';
+import { getSessionAgent } from '../src/auth/agent';
+
+const mockCheckMembership = vi.mocked(opensocial.checkMembership);
+const mockGetSessionAgent = vi.mocked(getSessionAgent);
+
+// Minimal AppContext — the middleware only uses it to pass to getSessionAgent.
+const ctx = {} as any;
+
+function makeReqRes(params: Record<string, string> = {}) {
+  const req: Partial<GroupAuthRequest> = { params };
+  const json = vi.fn();
+  const status = vi.fn().mockReturnValue({ json });
+  const res = { status, json } as unknown as Response;
+  const next: NextFunction = vi.fn();
+  return { req: req as GroupAuthRequest, res, next, json, status };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── requireGroupMember ────────────────────────────────────────────
+
+describe('requireGroupMember', () => {
+  it('returns 401 when there is no active session', async () => {
+    mockGetSessionAgent.mockResolvedValue(null as any);
+    const { req, res, next, status, json } = makeReqRes({ communityDid: 'did:plc:community1' });
+
+    await requireGroupMember(ctx)(req, res, next);
+
+    expect(status).toHaveBeenCalledWith(401);
+    expect(json).toHaveBeenCalledWith(expect.objectContaining({ error: expect.stringContaining('authenticated') }));
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when communityDid param is missing', async () => {
+    mockGetSessionAgent.mockResolvedValue({ did: 'did:plc:user1' } as any);
+    const { req, res, next, status, json } = makeReqRes({}); // no communityDid
+
+    await requireGroupMember(ctx)(req, res, next);
+
+    expect(status).toHaveBeenCalledWith(400);
+    expect(json).toHaveBeenCalledWith(expect.objectContaining({ error: expect.stringContaining('communityDid') }));
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when checkMembership returns isMember: false', async () => {
+    mockGetSessionAgent.mockResolvedValue({ did: 'did:plc:user1' } as any);
+    mockCheckMembership.mockResolvedValue({ isMember: false, isAdmin: false });
+    const { req, res, next, status } = makeReqRes({ communityDid: 'did:plc:community1' });
+
+    await requireGroupMember(ctx)(req, res, next);
+
+    expect(status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('calls next() and attaches groupAuth when user is a member', async () => {
+    mockGetSessionAgent.mockResolvedValue({ did: 'did:plc:user1' } as any);
+    mockCheckMembership.mockResolvedValue({ isMember: true, isAdmin: false });
+    const { req, res, next } = makeReqRes({ communityDid: 'did:plc:community1' });
+
+    await requireGroupMember(ctx)(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(req.groupAuth).toMatchObject({
+      userDid: 'did:plc:user1',
+      communityDid: 'did:plc:community1',
+      isMember: true,
+      isAdmin: false,
+    });
+  });
+
+  it('calls next() and marks isAdmin when user is an admin', async () => {
+    mockGetSessionAgent.mockResolvedValue({ did: 'did:plc:admin1' } as any);
+    mockCheckMembership.mockResolvedValue({ isMember: true, isAdmin: true });
+    const { req, res, next } = makeReqRes({ communityDid: 'did:plc:community1' });
+
+    await requireGroupMember(ctx)(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(req.groupAuth?.isAdmin).toBe(true);
+  });
+});
+
+// ── requireGroupAdmin ─────────────────────────────────────────────
+
+describe('requireGroupAdmin', () => {
+  it('returns 403 when groupAuth is already set but isAdmin is false', async () => {
+    const { req, res, next, status } = makeReqRes({ communityDid: 'did:plc:community1' });
+    // Pre-populate groupAuth as requireGroupMember would
+    req.groupAuth = {
+      userDid: 'did:plc:user1',
+      communityDid: 'did:plc:community1',
+      isMember: true,
+      isAdmin: false,
+    };
+
+    await requireGroupAdmin(ctx)(req, res, next);
+
+    expect(status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+    // Must NOT call checkMembership again — groupAuth is already populated
+    expect(mockCheckMembership).not.toHaveBeenCalled();
+  });
+
+  it('calls next() when groupAuth is already set and isAdmin is true', async () => {
+    const { req, res, next } = makeReqRes({ communityDid: 'did:plc:community1' });
+    req.groupAuth = {
+      userDid: 'did:plc:admin1',
+      communityDid: 'did:plc:community1',
+      isMember: true,
+      isAdmin: true,
+    };
+
+    await requireGroupAdmin(ctx)(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(mockCheckMembership).not.toHaveBeenCalled();
+  });
+
+  it('performs full membership check when groupAuth is not pre-set', async () => {
+    mockGetSessionAgent.mockResolvedValue({ did: 'did:plc:admin1' } as any);
+    mockCheckMembership.mockResolvedValue({ isMember: true, isAdmin: true });
+    const { req, res, next } = makeReqRes({ communityDid: 'did:plc:community1' });
+
+    await requireGroupAdmin(ctx)(req, res, next);
+
+    expect(mockCheckMembership).toHaveBeenCalledWith('did:plc:community1', 'did:plc:admin1');
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(req.groupAuth?.isAdmin).toBe(true);
+  });
+
+  it('returns 403 when full check finds user is a member but not admin', async () => {
+    mockGetSessionAgent.mockResolvedValue({ did: 'did:plc:user1' } as any);
+    mockCheckMembership.mockResolvedValue({ isMember: true, isAdmin: false });
+    const { req, res, next, status } = makeReqRes({ communityDid: 'did:plc:community1' });
+
+    await requireGroupAdmin(ctx)(req, res, next);
+
+    expect(status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when no session even in standalone admin check', async () => {
+    mockGetSessionAgent.mockResolvedValue(null as any);
+    const { req, res, next, status } = makeReqRes({ communityDid: 'did:plc:community1' });
+
+    await requireGroupAdmin(ctx)(req, res, next);
+
+    expect(status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/test/routes/reviewSegments.test.ts
+++ b/test/routes/reviewSegments.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Regression tests for the group segment progress route.
+ *
+ * Bug 1 (missing-createdAt): createCommunityRecord must include a `createdAt`
+ *   timestamp so PDS records have a stable created_at field.
+ *
+ * Bug 2: unauthenticated / non-member requests must receive 403.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { createRouter as createGroupContentRouter } from '../../src/routes/groupContent';
+
+// ── Module mocks ──────────────────────────────────────────────────
+// vi.mock() is hoisted so these run before imports.
+
+vi.mock('../../src/auth/agent', () => ({
+  getSessionAgent: vi.fn(),
+}));
+
+vi.mock('../../src/services/opensocial', () => ({
+  checkMembership: vi.fn(),
+  getCommunityRecord: vi.fn(),
+  listAllCommunityRecords: vi.fn(),
+  createCommunityRecord: vi.fn(),
+  listAllCommunityRecordsByMember: vi.fn(),
+  rkeyFromUri: vi.fn((uri: string) => uri.split('/').pop() ?? ''),
+}));
+
+// Notifications & group-post service — not under test, silence them
+vi.mock('../../src/services/notifications', () => ({
+  createNotification: vi.fn().mockResolvedValue(undefined),
+  notifyAllMembers: vi.fn().mockResolvedValue(undefined),
+  notifyUsers: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../src/services/groupPosts', () => ({
+  getPostsForSegment: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../../src/services/userProfiles', () => ({
+  getUserProfile: vi.fn().mockResolvedValue(null),
+}));
+
+import { getSessionAgent } from '../../src/auth/agent';
+import * as opensocial from '../../src/services/opensocial';
+
+const mockGetSessionAgent = vi.mocked(getSessionAgent);
+const mockCheckMembership = vi.mocked(opensocial.checkMembership);
+const mockGetCommunityRecord = vi.mocked(opensocial.getCommunityRecord);
+const mockListAllCommunityRecords = vi.mocked(opensocial.listAllCommunityRecords);
+const mockCreateCommunityRecord = vi.mocked(opensocial.createCommunityRecord);
+
+// ── Fixtures ──────────────────────────────────────────────────────
+
+const COMMUNITY_DID = 'did:plc:community1';
+const USER_DID = 'did:plc:user1';
+const SEGMENT_RKEY = 'seg123';
+const SEGMENT_URI = `at://${COMMUNITY_DID}/app.collectivesocial.group.segment/${SEGMENT_RKEY}`;
+
+const segmentRecord = {
+  uri: SEGMENT_URI,
+  cid: 'bafycid',
+  value: {
+    label: 'Chapters 1-5',
+    listItemUri: `at://${COMMUNITY_DID}/app.collectivesocial.group.listitem/item1`,
+  },
+};
+
+const progressRecord = {
+  uri: `at://${COMMUNITY_DID}/app.collectivesocial.group.segment.progress/prog1`,
+  cid: 'bafycid2',
+  value: {
+    segmentUri: SEGMENT_URI,
+    memberDid: USER_DID,
+    completed: true,
+    completedAt: '2026-05-08T21:23:32.000Z',
+    createdAt: '2026-05-08T21:23:32.000Z',
+  },
+};
+
+// Minimal AppContext — db, config, logger all unused by these routes in tests.
+function makeCtx() {
+  return {
+    logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+    db: {},
+    cfg: {},
+  } as any;
+}
+
+function buildApp() {
+  const ctx = makeCtx();
+  const app = express();
+  app.use(express.json());
+  // Mount with mergeParams to mirror real app: app.use('/groups/:communityDid', router)
+  const router = express.Router({ mergeParams: true });
+  router.use(createGroupContentRouter(ctx));
+  app.use('/groups/:communityDid', router);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── Tests ─────────────────────────────────────────────────────────
+
+describe('POST /groups/:communityDid/segments/:segmentRkey/progress', () => {
+  it('includes createdAt in the record sent to createCommunityRecord (regression: missing-createdAt bug)', async () => {
+    // Arrange: authenticated member
+    mockGetSessionAgent.mockResolvedValue({ did: USER_DID } as any);
+    mockCheckMembership.mockResolvedValue({ isMember: true, isAdmin: false });
+    mockGetCommunityRecord.mockResolvedValue(segmentRecord as any);
+    mockListAllCommunityRecords.mockResolvedValue([]);
+    mockCreateCommunityRecord.mockResolvedValue(progressRecord as any);
+
+    const app = buildApp();
+
+    // Act
+    const res = await request(app)
+      .post(`/groups/${encodeURIComponent(COMMUNITY_DID)}/segments/${SEGMENT_RKEY}/progress`)
+      .set('Cookie', 'session=fake');
+
+    // Assert: endpoint succeeded
+    expect(res.status).toBe(200);
+    expect(res.body.progress).toBeDefined();
+
+    // Assert: createdAt was forwarded to createCommunityRecord
+    expect(mockCreateCommunityRecord).toHaveBeenCalledTimes(1);
+    const [, , , record] = mockCreateCommunityRecord.mock.calls[0];
+    expect(record).toHaveProperty('createdAt');
+    expect(typeof (record as any).createdAt).toBe('string');
+    // Sanity check: completedAt is also present
+    expect(record).toHaveProperty('completedAt');
+  });
+
+  it('returns 403 when the user is not a member of the community', async () => {
+    // Arrange: authenticated but not a member
+    mockGetSessionAgent.mockResolvedValue({ did: USER_DID } as any);
+    mockCheckMembership.mockResolvedValue({ isMember: false, isAdmin: false });
+
+    const app = buildApp();
+
+    // Act
+    const res = await request(app)
+      .post(`/groups/${encodeURIComponent(COMMUNITY_DID)}/segments/${SEGMENT_RKEY}/progress`)
+      .set('Cookie', 'session=fake');
+
+    // Assert: membership gate is enforced
+    expect(res.status).toBe(403);
+    expect(mockCreateCommunityRecord).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Phase 1 authentication migration and bug fixes.

## What's in this branch
- **Auth migration:** OAuth scope definitions (`COLLECTIVE_SCOPES`) listing the 10 user-PDS collections the client requests write access to; group-PDS collections excluded (proxied via OpenSocial service credentials)
- **Bug fixes:** Group-related bug fixes from Phase 1 investigation
- **Tests absorbed:** `squad/phase1-tests` (regression tests + scope-check security tests) was absorbed into this branch — no separate PR for it

## Notes
⚠️ **F7 follow-up:** Some tests require `DATABASE_URL_TEST` env var — intentionally red in CI until env var is configured. Separate cleanup pass needed.