### PR TITLE
Phase 2: Backend architecture cleanups + events V1

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   integration:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,45 @@
+name: Integration Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: collective_test
+          POSTGRES_PASSWORD: test_password
+          POSTGRES_DB: collective_social_test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run integration tests
+        run: npm run test:integration
+        env:
+          NODE_ENV: test
+          DATABASE_URL_TEST: postgresql://collective_test:test_password@localhost:5432/collective_social_test
+          COOKIE_SECRET: test-secret-for-ci-integration-at-least-32-chars

--- a/lexicons/app.collectivesocial.feed.segmentprogress.json
+++ b/lexicons/app.collectivesocial.feed.segmentprogress.json
@@ -1,0 +1,36 @@
+{
+  "lexicon": 1,
+  "id": "app.collectivesocial.feed.segmentprogress",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Tracks the current user's completion of a reading/watching segment. Stored in the user's own PDS repo (not the community repo). One record per segment per user, keyed by segment rkey for idempotent upsert.",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["segmentUri", "communityDid", "completed", "createdAt"],
+        "properties": {
+          "segmentUri": {
+            "type": "string",
+            "format": "at-uri",
+            "description": "AT-URI of the app.collectivesocial.group.segment this progress record belongs to."
+          },
+          "communityDid": {
+            "type": "string",
+            "format": "did",
+            "description": "DID of the community that owns the segment. Used to scope reads and aggregation."
+          },
+          "completed": {
+            "type": "boolean",
+            "description": "Whether the user has completed this segment."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "When the user first marked this segment."
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/app.collectivesocial.group.postindex.json
+++ b/lexicons/app.collectivesocial.group.postindex.json
@@ -4,16 +4,20 @@
   "defs": {
     "main": {
       "type": "record",
-      "description": "Index entry in community repo pointing to a user's personal group post.",
+      "description": "Index entry in community repo pointing to a user's personal group post. The `post` field is a strongRef (uri + cid) so readers can verify integrity.",
       "key": "tid",
       "record": {
         "type": "object",
-        "required": ["postUri", "authorDid", "createdAt"],
+        "required": [
+          "post",
+          "authorDid",
+          "createdAt"
+        ],
         "properties": {
-          "postUri": {
-            "type": "string",
-            "format": "at-uri",
-            "description": "AT-URI of the post in the author's personal repo."
+          "post": {
+            "type": "ref",
+            "ref": "com.atproto.repo.strongRef",
+            "description": "StrongRef (uri + cid) of the post in the author's personal repo."
           },
           "authorDid": {
             "type": "string",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "format": "prettier --write \"src/**/*.{ts,js,json}\"",
     "format:check": "prettier --check \"src/**/*.{ts,js,json}\"",
     "lexgen": "lex gen-server ./src/lexicon ./lexicons/*",
-    "make-admin": "ts-node scripts/makeAdmin.ts"
+    "make-admin": "ts-node scripts/makeAdmin.ts",
+    "test:integration": "vitest run"
   },
   "author": "",
   "license": "ISC",

--- a/src/auth/client.ts
+++ b/src/auth/client.ts
@@ -10,6 +10,7 @@ import assert from 'node:assert';
 import type { Database } from '../db';
 import { config } from '../config';
 import { SessionStore, StateStore } from './storage';
+import { COLLECTIVE_SCOPES } from './scopes';
 
 export async function createOAuthClient(db: Database) {
   // Confidential client require a keyset accessible on the internet. Non
@@ -42,7 +43,7 @@ export async function createOAuthClient(db: Database) {
         client_id: `${config.serviceUrl}/oauth-client-metadata.json`,
         jwks_uri: `${config.serviceUrl}/.well-known/jwks.json`,
         redirect_uris: [`${config.serviceUrl}/oauth/callback`],
-        scope: 'atproto transition:generic',
+        scope: COLLECTIVE_SCOPES,
         grant_types: ['authorization_code', 'refresh_token'],
         response_types: ['code'],
         application_type: 'web',
@@ -53,7 +54,7 @@ export async function createOAuthClient(db: Database) {
     : atprotoLoopbackClientMetadata(
         `http://localhost?${new URLSearchParams([
           ['redirect_uri', `http://127.0.0.1:${config.port}/oauth/callback`],
-          ['scope', `atproto transition:generic`],
+          ['scope', COLLECTIVE_SCOPES],
         ])}`
       );
 
@@ -63,6 +64,8 @@ export async function createOAuthClient(db: Database) {
     stateStore: new StateStore(db),
     sessionStore: new SessionStore(db),
     plcDirectoryUrl: config.plcUrl,
-    handleResolver: config.pdsUrl,
+    // No handleResolver override — default AtprotoHandleResolverNode resolves
+    // handles via DNS TXT records and HTTP well-known, supporting any PDS.
+    allowHttp: config.nodeEnv === 'development',
   });
 }

--- a/src/auth/scopes.ts
+++ b/src/auth/scopes.ts
@@ -1,0 +1,13 @@
+/**
+ * OAuth scope string for Collective Social.
+ *
+ * Lists the 10 user-PDS collections that the OAuth client requests write
+ * access to. Group-PDS collections are excluded because those writes are
+ * proxied through the OpenSocial service using its own service credentials,
+ * not the user's OAuth token.
+ *
+ * Decided: 2026-05-08 by Simon — see
+ * .squad/decisions/inbox/simon-nsid-scopes.md
+ */
+export const COLLECTIVE_SCOPES =
+  'atproto repo:app.collectivesocial.feed.list repo:app.collectivesocial.feed.listitem repo:app.collectivesocial.feed.useritem repo:app.collectivesocial.feed.review repo:app.collectivesocial.feed.completion repo:app.collectivesocial.feed.comment repo:app.collectivesocial.feed.react repo:app.collectivesocial.feed.reviewsegment repo:app.collectivesocial.feed.goal repo:app.collectivesocial.feed.grouppost';

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,9 @@ app.use(
   cors({
     origin:
       config.nodeEnv === 'production'
-        ? (config.corsOrigin ? [config.corsOrigin] : [])
+        ? config.corsOrigin
+          ? [config.corsOrigin]
+          : []
         : ['http://127.0.0.1:5173', 'http://localhost:5173'],
     credentials: true,
   })
@@ -77,21 +79,25 @@ app.use((req, _res, next) => {
         const collection = decodeURIComponent(segments[1]);
         const rkey = decodeURIComponent(segments[2]);
         const atUri = `at://${did}/${collection}/${rkey}`;
-        const suffix = segments.length > 3 ? '/' + segments.slice(3).join('/') : '';
+        const suffix =
+          segments.length > 3 ? '/' + segments.slice(3).join('/') : '';
 
         // Recursively handle a second AT URI in the suffix (e.g. /items/:itemUri)
         let processedSuffix = suffix;
         const innerMatch = suffix.match(/\/at(?:%3A|:)\/{1,2}/i);
         if (innerMatch && innerMatch.index !== undefined) {
           const sPre = suffix.substring(0, innerMatch.index + 1);
-          const sAfterAt = suffix.substring(innerMatch.index + innerMatch[0].length);
+          const sAfterAt = suffix.substring(
+            innerMatch.index + innerMatch[0].length
+          );
           const innerSegs = sAfterAt.split('/');
           if (innerSegs.length >= 3) {
             const iDid = decodeURIComponent(innerSegs[0]);
             const iCol = decodeURIComponent(innerSegs[1]);
             const iRkey = decodeURIComponent(innerSegs[2]);
             const innerAtUri = `at://${iDid}/${iCol}/${iRkey}`;
-            const iSuffix = innerSegs.length > 3 ? '/' + innerSegs.slice(3).join('/') : '';
+            const iSuffix =
+              innerSegs.length > 3 ? '/' + innerSegs.slice(3).join('/') : '';
             processedSuffix = sPre + encodeURIComponent(innerAtUri) + iSuffix;
           }
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { createRouter as createCommentsRouter } from './routes/comments';
 import { createRouter as createReactionsRouter } from './routes/reactions';
 import { createRouter as createGroupsRouter } from './routes/groups';
 import { createRouter as createGroupContentRouter } from './routes/groupContent';
+import { createRouter as createGroupEventsRouter } from './routes/groupEvents';
 import { createRouter as createNotificationsRouter } from './routes/notifications';
 import { createRouter as createUseritemsRouter } from './routes/useritems';
 import { createRouter as createCompletionsRouter } from './routes/completions';
@@ -131,6 +132,7 @@ createAppContext().then((ctx) => {
   app.use('/reactions', createReactionsRouter(ctx));
   app.use('/groups', createGroupsRouter(ctx));
   app.use('/groups/:communityDid', createGroupContentRouter(ctx));
+  app.use('/groups/:communityDid/events', createGroupEventsRouter(ctx));
   app.use('/notifications', createNotificationsRouter(ctx));
   app.use('/useritems', createUseritemsRouter(ctx));
   app.use('/completions', createCompletionsRouter(ctx));

--- a/src/middleware/trackUserActivity.ts
+++ b/src/middleware/trackUserActivity.ts
@@ -185,10 +185,7 @@ export function createUserActivityTracker(ctx: AppContext) {
             DO UPDATE SET activity_count = user_activity_log.activity_count + 1
           `.execute(ctx.db);
         } catch (activityErr) {
-          ctx.logger.error(
-            { err: activityErr },
-            'Failed to log user activity'
-          );
+          ctx.logger.error({ err: activityErr }, 'Failed to log user activity');
         }
       }
     } catch (err) {

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -641,6 +641,55 @@ migrations['027'] = {
   },
 };
 
+// ────────────────────────────────────────────────────────────────────────────
+// Migration 028: event_rsvps table for Events V1
+// Events live on the group PDS (community.lexicon.calendar.event).
+// RSVPs live on each user's PDS (community.lexicon.calendar.rsvp).
+// This table caches RSVPs for aggregation (counts, attendee lists).
+// ────────────────────────────────────────────────────────────────────────────
+migrations['028'] = {
+  async up(db: Kysely<unknown>) {
+    await db.schema
+      .createTable('event_rsvps')
+      .addColumn('event_uri', 'text', (col) => col.notNull())
+      .addColumn('event_cid', 'text', (col) => col.notNull())
+      .addColumn('community_did', 'text', (col) => col.notNull())
+      .addColumn('user_did', 'text', (col) => col.notNull())
+      .addColumn('rsvp_uri', 'text', (col) => col.notNull())
+      .addColumn('status', 'varchar(16)', (col) => col.notNull())
+      .addColumn('rsvp_at', 'timestamptz', (col) =>
+        col.notNull().defaultTo(sql`NOW()`)
+      )
+      .addColumn('updated_at', 'timestamptz', (col) =>
+        col.notNull().defaultTo(sql`NOW()`)
+      )
+      .addPrimaryKeyConstraint('event_rsvps_pkey', ['event_uri', 'user_did'])
+      .execute();
+
+    await db.schema
+      .createIndex('event_rsvps_event_uri_idx')
+      .on('event_rsvps')
+      .column('event_uri')
+      .execute();
+
+    await db.schema
+      .createIndex('event_rsvps_community_did_idx')
+      .on('event_rsvps')
+      .column('community_did')
+      .execute();
+
+    await db.schema
+      .createIndex('event_rsvps_user_did_idx')
+      .on('event_rsvps')
+      .column('user_did')
+      .execute();
+  },
+
+  async down(db: Kysely<unknown>) {
+    await db.schema.dropTable('event_rsvps').ifExists().execute();
+  },
+};
+
 export { migrations, migrationProvider };
 
 export const migrateToLatest = async (db: Kysely<any>) => {

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -522,7 +522,9 @@ migrations['026'] = {
       .createTable('user_activity_log')
       .addColumn('did', 'varchar', (col) => col.notNull())
       .addColumn('activity_date', 'date', (col) => col.notNull())
-      .addColumn('activity_count', 'integer', (col) => col.notNull().defaultTo(1))
+      .addColumn('activity_count', 'integer', (col) =>
+        col.notNull().defaultTo(1)
+      )
       .addUniqueConstraint('user_activity_log_did_date_unique', [
         'did',
         'activity_date',
@@ -583,10 +585,7 @@ migrations['026'] = {
       .dropIndex('feed_events_event_type_idx')
       .ifExists()
       .execute();
-    await db.schema
-      .alterTable('feed_events')
-      .dropColumn('eventType')
-      .execute();
+    await db.schema.alterTable('feed_events').dropColumn('eventType').execute();
     await db.schema.dropTable('bluesky_share_events').ifExists().execute();
     await db.schema.dropTable('user_activity_log').ifExists().execute();
   },
@@ -633,10 +632,7 @@ migrations['027'] = {
   },
 
   async down(db: Kysely<unknown>) {
-    await db.schema
-      .alterTable('share_links')
-      .dropColumn('goalUri')
-      .execute();
+    await db.schema.alterTable('share_links').dropColumn('goalUri').execute();
     await db.schema.dropTable('goals').ifExists().execute();
   },
 };

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,34 +1,8 @@
 import express, { Request, Response } from 'express';
-import { getIronSession } from 'iron-session';
 import type { AppContext } from '../context';
-import { config } from '../config';
 import { handler } from '../lib/http';
-import { Agent } from '@atproto/api';
 import { fetchUserHandles } from '../lib/users';
-
-type Session = { did?: string };
-
-// Helper function to get the authenticated user's session
-async function getSessionAgent(
-  req: express.Request,
-  res: express.Response,
-  ctx: AppContext
-) {
-  res.setHeader('Vary', 'Cookie');
-
-  const session = await getIronSession<Session>(req, res, {
-    cookieName: 'sid',
-    password: config.cookieSecret,
-    cookieOptions: {
-      secure: config.nodeEnv === 'production',
-      sameSite: 'lax',
-      httpOnly: true,
-      path: '/',
-    },
-  });
-
-  return session.did || null;
-}
+import { getSessionAgent } from '../auth/agent';
 
 // Middleware to check if user is admin
 async function requireAdmin(
@@ -36,9 +10,9 @@ async function requireAdmin(
   res: express.Response,
   ctx: AppContext
 ): Promise<boolean> {
-  const did = await getSessionAgent(req, res, ctx);
+  const agent = await getSessionAgent(req, res, ctx);
 
-  if (!did) {
+  if (!agent?.did) {
     res.status(401).json({ error: 'Not authenticated' });
     return false;
   }
@@ -46,7 +20,7 @@ async function requireAdmin(
   const user = await ctx.db
     .selectFrom('users')
     .select(['isAdmin'])
-    .where('did', '=', did)
+    .where('did', '=', agent.did)
     .executeTakeFirst();
 
   if (!user?.isAdmin) {
@@ -94,23 +68,18 @@ export const createRouter = (ctx: AppContext) => {
           .execute();
 
         // Get admin agent for fetching user handles
-        const sessionDid = await getSessionAgent(req, res, ctx);
+        const adminAgent = await getSessionAgent(req, res, ctx);
         let userHandles = new Map<string, string>();
 
-        if (sessionDid) {
+        if (adminAgent) {
           try {
-            const oauthSession = await ctx.oauthClient.restore(sessionDid);
-            if (oauthSession) {
-              const adminAgent = new Agent(oauthSession);
-
-              // Fetch user handles
-              const userDids = users.map((user) => user.did);
-              userHandles = await fetchUserHandles(
-                adminAgent,
-                userDids,
-                ctx.logger
-              );
-            }
+            // Fetch user handles
+            const userDids = users.map((user) => user.did);
+            userHandles = await fetchUserHandles(
+              adminAgent,
+              userDids,
+              ctx.logger
+            );
           } catch (err) {
             ctx.logger.error(
               { err },
@@ -272,27 +241,20 @@ export const createRouter = (ctx: AppContext) => {
         const origin = req.get('origin') || 'http://127.0.0.1:5173';
 
         // Get admin agent for fetching user handles and collection names
-        const sessionDid = await getSessionAgent(req, res, ctx);
+        const adminAgentForCollections = await getSessionAgent(req, res, ctx);
         let userHandles = new Map<string, string>();
-        let adminAgentForCollections: Agent | null = null;
 
-        if (sessionDid) {
+        if (adminAgentForCollections) {
           try {
-            const oauthSession = await ctx.oauthClient.restore(sessionDid);
-            if (oauthSession) {
-              const adminAgent = new Agent(oauthSession);
-              adminAgentForCollections = adminAgent;
-
-              // Fetch user handles
-              const uniqueUserDids = [
-                ...new Set(shareLinks.map((link) => link.userDid)),
-              ];
-              userHandles = await fetchUserHandles(
-                adminAgent,
-                uniqueUserDids,
-                ctx.logger
-              );
-            }
+            // Fetch user handles
+            const uniqueUserDids = [
+              ...new Set(shareLinks.map((link) => link.userDid)),
+            ];
+            userHandles = await fetchUserHandles(
+              adminAgentForCollections,
+              uniqueUserDids,
+              ctx.logger
+            );
           } catch (err) {
             ctx.logger.error(
               { err },
@@ -425,16 +387,16 @@ export const createRouter = (ctx: AppContext) => {
     handler(async (req: Request, res: Response) => {
       res.setHeader('cache-control', 'no-store');
 
-      const did = await getSessionAgent(req, res, ctx);
+      const agent = await getSessionAgent(req, res, ctx);
 
-      if (!did) {
+      if (!agent?.did) {
         return res.json({ isAdmin: false });
       }
 
       const user = await ctx.db
         .selectFrom('users')
         .select(['isAdmin'])
-        .where('did', '=', did)
+        .where('did', '=', agent.did)
         .executeTakeFirst();
 
       res.json({ isAdmin: user?.isAdmin || false });

--- a/src/routes/analytics.ts
+++ b/src/routes/analytics.ts
@@ -86,9 +86,7 @@ export const createRouter = (ctx: AppContext) => {
         });
       } catch (err) {
         ctx.logger.error({ err }, 'Failed to fetch weekly active users');
-        res
-          .status(500)
-          .json({ error: 'Failed to fetch weekly active users' });
+        res.status(500).json({ error: 'Failed to fetch weekly active users' });
       }
     })
   );

--- a/src/routes/analytics.ts
+++ b/src/routes/analytics.ts
@@ -2,10 +2,8 @@ import express, { Request, Response } from 'express';
 import { getIronSession } from 'iron-session';
 import { sql } from 'kysely';
 import type { AppContext } from '../context';
-import { config } from '../config';
 import { handler } from '../lib/http';
-
-type Session = { did?: string };
+import { SESSION_OPTIONS, Session } from '../auth/session';
 
 async function requireAdmin(
   req: express.Request,
@@ -13,16 +11,7 @@ async function requireAdmin(
   ctx: AppContext
 ): Promise<boolean> {
   res.setHeader('Vary', 'Cookie');
-  const session = await getIronSession<Session>(req, res, {
-    cookieName: 'sid',
-    password: config.cookieSecret,
-    cookieOptions: {
-      secure: config.nodeEnv === 'production',
-      sameSite: 'lax',
-      httpOnly: true,
-      path: '/',
-    },
-  });
+  const session = await getIronSession<Session>(req, res, SESSION_OPTIONS);
   if (!session.did) {
     res.status(401).json({ error: 'Not authenticated' });
     return false;

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -74,7 +74,11 @@ export const createRouter = (ctx: AppContext): RequestListener => {
       const params = new URLSearchParams(req.originalUrl.split('?')[1]);
       try {
         // Load the session cookie
-        const session = await getIronSession<Session>(req, res, SESSION_OPTIONS);
+        const session = await getIronSession<Session>(
+          req,
+          res,
+          SESSION_OPTIONS
+        );
 
         // If the user is already signed in, destroy the old credentials
         if (session.did) {

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -11,6 +11,7 @@ import { config } from '../config';
 import { handler } from '../lib/http';
 import { ifString } from '../lib/stringUtil';
 import { SESSION_OPTIONS, Session } from '../auth/session';
+import { COLLECTIVE_SCOPES } from '../auth/scopes';
 
 // Max age, in seconds, for static routes and assets
 const MAX_AGE = config.nodeEnv === 'production' ? 60 : 300;
@@ -73,16 +74,7 @@ export const createRouter = (ctx: AppContext): RequestListener => {
       const params = new URLSearchParams(req.originalUrl.split('?')[1]);
       try {
         // Load the session cookie
-        const session = await getIronSession<Session>(req, res, {
-          cookieName: 'sid',
-          password: config.cookieSecret,
-          cookieOptions: {
-            secure: config.nodeEnv === 'production',
-            sameSite: 'lax',
-            httpOnly: true,
-            path: '/',
-          },
-        });
+        const session = await getIronSession<Session>(req, res, SESSION_OPTIONS);
 
         // If the user is already signed in, destroy the old credentials
         if (session.did) {
@@ -129,7 +121,7 @@ export const createRouter = (ctx: AppContext): RequestListener => {
 
         // Initiate the OAuth flow
         const url = await ctx.oauthClient.authorize(input, {
-          scope: 'atproto transition:generic',
+          scope: COLLECTIVE_SCOPES,
         });
 
         res.redirect(url.toString());
@@ -152,7 +144,7 @@ export const createRouter = (ctx: AppContext): RequestListener => {
       try {
         const service = config.pdsUrl;
         const url = await ctx.oauthClient.authorize(service, {
-          scope: 'atproto transition:generic',
+          scope: COLLECTIVE_SCOPES,
         });
         res.redirect(url.toString());
       } catch (err) {
@@ -174,16 +166,7 @@ export const createRouter = (ctx: AppContext): RequestListener => {
       // Never store this route
       res.setHeader('cache-control', 'no-store');
 
-      const session = await getIronSession<Session>(req, res, {
-        cookieName: 'sid',
-        password: config.cookieSecret,
-        cookieOptions: {
-          secure: config.nodeEnv === 'production',
-          sameSite: 'lax',
-          httpOnly: true,
-          path: '/',
-        },
-      });
+      const session = await getIronSession<Session>(req, res, SESSION_OPTIONS);
 
       // Revoke credentials on the server
       if (session.did) {

--- a/src/routes/collections.ts
+++ b/src/routes/collections.ts
@@ -485,7 +485,8 @@ export const createRouter = (ctx: AppContext) => {
                     record.value.order !== undefined ? record.value.order : 0,
                   mediaType: record.value.mediaType || null,
                   mediaItemId: record.value.mediaItemId || null,
-                  userItemUri: record.value.userItem || useritemData.uri || null,
+                  userItemUri:
+                    record.value.userItem || useritemData.uri || null,
                   // Enriched from useritem
                   status: useritemData.status || null,
                   rating: useritemData.rating ?? null,
@@ -524,7 +525,11 @@ export const createRouter = (ctx: AppContext) => {
                 return item;
               } catch (err) {
                 ctx.logger.warn(
-                  { err, uri: record.uri, mediaItemId: record.value?.mediaItemId },
+                  {
+                    err,
+                    uri: record.uri,
+                    mediaItemId: record.value?.mediaItemId,
+                  },
                   'Failed to enrich collection item, skipping'
                 );
                 return null;
@@ -533,7 +538,9 @@ export const createRouter = (ctx: AppContext) => {
         );
 
         // Filter out any items that failed to load
-        const items = itemResults.filter((item): item is NonNullable<typeof item> => item !== null);
+        const items = itemResults.filter(
+          (item): item is NonNullable<typeof item> => item !== null
+        );
 
         // Sort by order (descending - higher numbers first)
         items.sort((a, b) => (b.order || 0) - (a.order || 0));

--- a/src/routes/comments.ts
+++ b/src/routes/comments.ts
@@ -63,7 +63,9 @@ export const createRouter = (ctx: AppContext) => {
           updatedAt: now,
         };
 
-        // If we have a reviewUri, try to fetch the review to get its CID
+        // If we have a reviewUri, fetch the review to get its CID for the strongRef.
+        // A strongRef requires both uri and cid; if we cannot obtain the real CID we
+        // must not proceed — using a fake CID would break tamper-evidence guarantees.
         if (reviewUri && record.reviewRef) {
           try {
             const uriParts = reviewUri.split('/');
@@ -78,17 +80,19 @@ export const createRouter = (ctx: AppContext) => {
 
             record.reviewRef.cid = reviewRecord.data.cid as string;
           } catch (err) {
-            // If review doesn't exist in AT Protocol, use a placeholder CID
-            // The comment will still be stored in our database
-            ctx.logger.warn(
+            ctx.logger.error(
               { err, reviewUri },
-              'Could not fetch review CID, using placeholder'
+              'Could not fetch review CID; cannot create valid strongRef — aborting comment creation'
             );
-            record.reviewRef.cid = 'bafyreib2rxk3rh6kzwq';
+            return res.status(502).json({
+              error:
+                'Could not fetch the referenced review record. The review may have been deleted or is temporarily unavailable. Please try again.',
+            });
           }
         }
 
-        // If we have a parentCommentUri, try to fetch the parent comment to get its CID
+        // If we have a parentCommentUri, fetch its CID for the strongRef.
+        // Same rule: no real CID → no write.
         if (parentCommentUri && record.parentCommentRef) {
           try {
             const uriParts = parentCommentUri.split('/');
@@ -103,12 +107,14 @@ export const createRouter = (ctx: AppContext) => {
 
             record.parentCommentRef.cid = parentRecord.data.cid as string;
           } catch (err) {
-            // If parent comment doesn't exist in AT Protocol, use a placeholder CID
-            ctx.logger.warn(
+            ctx.logger.error(
               { err, parentCommentUri },
-              'Could not fetch parent comment CID, using placeholder'
+              'Could not fetch parent comment CID; cannot create valid strongRef — aborting comment creation'
             );
-            record.parentCommentRef.cid = 'bafyreib2rxk3rh6kzwq';
+            return res.status(502).json({
+              error:
+                'Could not fetch the referenced parent comment. It may have been deleted or is temporarily unavailable. Please try again.',
+            });
           }
         }
 

--- a/src/routes/completions.ts
+++ b/src/routes/completions.ts
@@ -139,7 +139,9 @@ export const createRouter = (ctx: AppContext) => {
         return res.status(401).json({ error: 'Not authenticated' });
       }
 
-      const completionUri = decodeURIComponent(req.params.completionUri as string);
+      const completionUri = decodeURIComponent(
+        req.params.completionUri as string
+      );
       const rkeyMatch = completionUri.match(/\/([^\/]+)$/);
       if (!rkeyMatch) {
         return res.status(400).json({ error: 'Invalid completion URI' });

--- a/src/routes/goals.ts
+++ b/src/routes/goals.ts
@@ -115,9 +115,7 @@ export const createRouter = (ctx: AppContext) => {
           completedCount: cachedMap.get(g.uri) ?? 0,
           percentage: Math.min(
             100,
-            Math.round(
-              ((cachedMap.get(g.uri) ?? 0) / g.targetCount) * 100
-            )
+            Math.round(((cachedMap.get(g.uri) ?? 0) / g.targetCount) * 100)
           ),
         }));
 
@@ -466,9 +464,7 @@ export const createRouter = (ctx: AppContext) => {
           completedCount: cachedMap.get(g.uri) ?? 0,
           percentage: Math.min(
             100,
-            Math.round(
-              ((cachedMap.get(g.uri) ?? 0) / g.targetCount) * 100
-            )
+            Math.round(((cachedMap.get(g.uri) ?? 0) / g.targetCount) * 100)
           ),
         }));
 

--- a/src/routes/groupContent.ts
+++ b/src/routes/groupContent.ts
@@ -32,7 +32,10 @@ const COL_LIST = 'app.collectivesocial.group.list';
 const COL_LISTITEM = 'app.collectivesocial.group.listitem';
 const COL_LISTITEM_STATUS = 'app.collectivesocial.group.listitem.status';
 const COL_SEGMENT = 'app.collectivesocial.group.segment';
-const COL_SEGMENT_PROGRESS = 'app.collectivesocial.group.segment.progress';
+// Segment progress now lives in the user's own PDS (B5 decision).
+// The old community-PDS collection (app.collectivesocial.group.segment.progress)
+// is no longer written to; existing records in the community repo are obsolete.
+const COL_SEGMENT_PROGRESS_USER = 'app.collectivesocial.feed.segmentprogress';
 const COL_POST = 'app.collectivesocial.group.post';
 const COL_REACTION = 'app.collectivesocial.group.reaction';
 
@@ -579,6 +582,11 @@ export const createRouter = (ctx: AppContext) => {
       const { communityDid } = req.groupAuth!;
       const itemRkey = req.params.itemRkey as string;
 
+      const agent = await getSessionAgent(req, res, ctx);
+      if (!agent) {
+        return res.status(401).json({ error: 'Not authenticated' });
+      }
+
       let item: PdsRecord;
       try {
         item = await opensocial.getCommunityRecord(
@@ -598,35 +606,35 @@ export const createRouter = (ctx: AppContext) => {
       const itemSegments = allSegments.filter(
         (r: any) => r.value.listItemUri === item.uri
       );
-      const segmentUris = new Set(itemSegments.map((s) => s.uri));
 
-      // Get ALL progress records once (not per-segment)
-      let allProgress: PdsRecord[] = [];
-      try {
-        allProgress = await opensocial.listAllCommunityRecords(
-          communityDid,
-          COL_SEGMENT_PROGRESS
-        );
-      } catch (err) {
-        console.error('Failed to list segment progress:', err);
-      }
-
-      // Group progress by segment URI
+      // Fetch the current user's progress records from their PDS for each segment.
+      // rkey = segmentRkey (by convention set at write time), so we look them
+      // up directly rather than listing the entire collection.
       const progressBySegment: Record<
         string,
-        Array<{ uri: string; rkey: string; [k: string]: unknown }>
+        { uri: string; rkey: string; [k: string]: unknown } | null
       > = {};
-      for (const p of allProgress) {
-        const segUri = (p.value as any).segmentUri as string;
-        if (segmentUris.has(segUri)) {
-          if (!progressBySegment[segUri]) progressBySegment[segUri] = [];
-          progressBySegment[segUri].push({
-            uri: p.uri,
-            rkey: rkeyFromUri(p.uri),
-            ...p.value,
-          });
-        }
-      }
+
+      await Promise.all(
+        itemSegments.map(async (seg) => {
+          const segRkey = rkeyFromUri(seg.uri);
+          try {
+            const rec = await agent.api.com.atproto.repo.getRecord({
+              repo: agent.did!,
+              collection: COL_SEGMENT_PROGRESS_USER,
+              rkey: segRkey,
+            });
+            progressBySegment[seg.uri] = {
+              uri: rec.data.uri,
+              rkey: segRkey,
+              ...(rec.data.value as object),
+            };
+          } catch {
+            // No progress record for this segment — user hasn't marked it yet
+            progressBySegment[seg.uri] = null;
+          }
+        })
+      );
 
       return res.json({ progressBySegment });
     })
@@ -870,22 +878,10 @@ export const createRouter = (ctx: AppContext) => {
         return res.status(404).json({ error: 'Segment not found' });
       }
 
-      // Delete progress records for this segment
-      const allProgress = await opensocial.listAllCommunityRecords(
-        communityDid,
-        COL_SEGMENT_PROGRESS
-      );
-      const segProgress = allProgress.filter(
-        (r: any) => r.value.segmentUri === segment.uri
-      );
-      for (const prog of segProgress) {
-        await opensocial.deleteCommunityRecord(
-          communityDid,
-          userDid,
-          COL_SEGMENT_PROGRESS,
-          rkeyFromUri(prog.uri)
-        );
-      }
+      // NOTE: Segment progress records now live in each user's personal PDS
+      // (app.collectivesocial.feed.segmentprogress). The server cannot enumerate
+      // or delete them on behalf of users; they will become orphaned stale records.
+      // Deferred: a future per-user "clear progress" flow can handle cleanup.
 
       // Delete child posts + reactions
       const allPosts = await opensocial.listAllCommunityRecords(
@@ -936,22 +932,36 @@ export const createRouter = (ctx: AppContext) => {
         return res.status(404).json({ error: 'Segment not found' });
       }
 
-      const allProgress = await opensocial.listAllCommunityRecords(
-        communityDid,
-        COL_SEGMENT_PROGRESS
-      );
-      const segmentProgress = allProgress
-        .filter((r: any) => r.value.segmentUri === segment.uri)
-        .map((r) => ({ uri: r.uri, rkey: rkeyFromUri(r.uri), ...r.value }));
+      // Progress is now in user's own PDS. Return the current user's record only.
+      const agent = await getSessionAgent(req, res, ctx);
+      if (!agent) {
+        return res.status(401).json({ error: 'Not authenticated' });
+      }
 
-      return res.json({ progress: segmentProgress });
+      let progress = null;
+      try {
+        const rec = await agent.api.com.atproto.repo.getRecord({
+          repo: agent.did!,
+          collection: COL_SEGMENT_PROGRESS_USER,
+          rkey: segmentRkey,
+        });
+        progress = { uri: rec.data.uri, rkey: segmentRkey, ...(rec.data.value as object) };
+      } catch {
+        // No progress record yet
+      }
+
+      return res.json({ progress });
     })
   );
 
   /**
    * POST /groups/:communityDid/segments/:segmentRkey/progress
    * Mark the current user as having completed a segment.
-   * Also syncs to the user's personal progress (reviewsegment + useritem).
+   *
+   * Writes app.collectivesocial.feed.segmentprogress to the USER's own PDS
+   * using the segmentRkey as the record rkey (idempotent putRecord).
+   * The sync calls below (/reviewsegments and /collections/quick-add) remain
+   * as the primary path for updating the user's personal library (B5 pattern).
    *
    * Body: {} (no fields needed — uses auth context)
    */
@@ -961,6 +971,11 @@ export const createRouter = (ctx: AppContext) => {
     handler(async (req: GroupAuthRequest, res: Response) => {
       const { userDid, communityDid } = req.groupAuth!;
       const segmentRkey = req.params.segmentRkey as string;
+
+      const agent = await getSessionAgent(req, res, ctx);
+      if (!agent) {
+        return res.status(401).json({ error: 'Not authenticated' });
+      }
 
       let segment: PdsRecord;
       try {
@@ -973,64 +988,56 @@ export const createRouter = (ctx: AppContext) => {
         return res.status(404).json({ error: 'Segment not found' });
       }
 
-      // Check for duplicate — member may have already marked this segment
-      let allProgress: PdsRecord[];
+      // Check for duplicate using user's own PDS (rkey = segmentRkey is idempotent)
       try {
-        allProgress = await opensocial.listAllCommunityRecords(
-          communityDid,
-          COL_SEGMENT_PROGRESS
-        );
-      } catch (err) {
-        console.error('Failed to list segment progress records:', err);
-        allProgress = [];
-      }
-
-      const existing = allProgress.find(
-        (r: any) =>
-          r.value.segmentUri === segment.uri && r.value.memberDid === userDid
-      );
-      if (existing) {
-        return res.json({
-          progress: {
-            uri: existing.uri,
-            rkey: rkeyFromUri(existing.uri),
-            ...existing.value,
-          },
-          alreadyExists: true,
+        const existingRecord = await agent.api.com.atproto.repo.getRecord({
+          repo: agent.did!,
+          collection: COL_SEGMENT_PROGRESS_USER,
+          rkey: segmentRkey,
         });
+        if (existingRecord.data) {
+          return res.json({
+            progress: {
+              uri: existingRecord.data.uri,
+              rkey: segmentRkey,
+              ...(existingRecord.data.value as object),
+            },
+            alreadyExists: true,
+          });
+        }
+      } catch {
+        // Record doesn't exist yet — proceed to create
       }
 
       const now = new Date().toISOString();
+      const progressRecord = {
+        $type: COL_SEGMENT_PROGRESS_USER,
+        segmentUri: segment.uri,
+        communityDid,
+        completed: true,
+        createdAt: now,
+      };
 
-      let pdsRecord;
+      let userPdsResponse;
       try {
-        pdsRecord = await opensocial.createCommunityRecord(
-          communityDid,
-          userDid,
-          COL_SEGMENT_PROGRESS,
-          {
-            segmentUri: segment.uri,
-            memberDid: userDid,
-            completed: true,
-            completedAt: now,
-            createdAt: now,
-          }
-        );
-      } catch (err: any) {
-        console.error('Failed to create segment progress record:', err);
-        return res.status(err.status || 500).json({
-          error: err.message || 'Failed to create progress record',
+        userPdsResponse = await agent.api.com.atproto.repo.putRecord({
+          repo: agent.did!,
+          collection: COL_SEGMENT_PROGRESS_USER,
+          rkey: segmentRkey,
+          record: progressRecord as any,
         });
+      } catch (err: any) {
+        ctx.logger.error({ err }, 'Failed to write segment progress to user PDS');
+        return res.status(500).json({ error: 'Failed to create progress record' });
       }
 
       // ── Sync to personal progress ──────────────────────────────
       // If the segment has an endPercent, create/update a personal
       // reviewsegment at that percentage for the user's library.
+      // These calls are the primary B5 sync — they remain unchanged.
       const segVal = segment.value as any;
       if (segVal.endPercent != null) {
         try {
-          // Forward to the personal reviewsegment endpoint
-          // This is an internal call — the user's session cookie is on the request
           const itemRecord = await opensocial.getCommunityRecord(
             communityDid,
             COL_LISTITEM,
@@ -1039,7 +1046,6 @@ export const createRouter = (ctx: AppContext) => {
           const itemVal = itemRecord.value as any;
 
           if (itemVal.mediaItemId) {
-            // Create personal review segment via internal API call
             const syncBody = {
               percentage: segVal.endPercent,
               title: segVal.label,
@@ -1047,30 +1053,20 @@ export const createRouter = (ctx: AppContext) => {
               mediaType: itemVal.mediaType,
             };
 
-            // Use the user's cookie to call the personal reviewsegment endpoint
             const cookie = req.headers.cookie;
             if (cookie) {
               const baseUrl = `${req.protocol}://${req.get('host')}`;
               await fetch(`${baseUrl}/reviewsegments`, {
                 method: 'POST',
-                headers: {
-                  'Content-Type': 'application/json',
-                  Cookie: cookie,
-                },
+                headers: { 'Content-Type': 'application/json', Cookie: cookie },
                 body: JSON.stringify(syncBody),
               }).catch((err) => {
-                console.warn('Failed to sync personal review segment:', err);
+                ctx.logger.warn({ err }, 'Failed to sync personal review segment');
               });
 
-              // Also ensure the user's personal useritem status is 'in-progress'
-              // if it's currently 'want'. We do this via the quick-add endpoint
-              // which handles finding/creating the default list and upserting useritem.
               await fetch(`${baseUrl}/collections/quick-add`, {
                 method: 'POST',
-                headers: {
-                  'Content-Type': 'application/json',
-                  Cookie: cookie,
-                },
+                headers: { 'Content-Type': 'application/json', Cookie: cookie },
                 body: JSON.stringify({
                   mediaItemId: itemVal.mediaItemId,
                   mediaType: itemVal.mediaType,
@@ -1079,46 +1075,56 @@ export const createRouter = (ctx: AppContext) => {
                   status: 'in-progress',
                 }),
               }).catch((err) => {
-                console.warn('Failed to sync personal collection:', err);
+                ctx.logger.warn({ err }, 'Failed to sync personal collection');
               });
             }
           }
         } catch (syncErr) {
-          console.warn('Failed to sync personal progress:', syncErr);
-          // Non-fatal — the group progress is still recorded
+          ctx.logger.warn({ err: syncErr }, 'Failed to sync personal progress');
+          // Non-fatal — the user PDS progress record is already written
         }
       }
 
       return res.json({
         progress: {
-          uri: pdsRecord.uri,
-          rkey: rkeyFromUri(pdsRecord.uri),
+          uri: userPdsResponse.data.uri,
+          rkey: segmentRkey,
           segmentUri: segment.uri,
-          memberDid: userDid,
+          communityDid,
           completed: true,
-          completedAt: now,
+          createdAt: now,
         },
       });
     })
   );
 
   /**
-   * DELETE /groups/:communityDid/segments/:segmentRkey/progress/:rkey
+   * DELETE /groups/:communityDid/segments/:segmentRkey/progress
    * Unmark the current user's completion of a segment.
+   * Deletes the app.collectivesocial.feed.segmentprogress record from user PDS.
+   * rkey = segmentRkey (matches the idempotent putRecord on creation).
    */
   router.delete(
-    '/segments/:segmentRkey/progress/:rkey',
+    '/segments/:segmentRkey/progress',
     memberOnly,
     handler(async (req: GroupAuthRequest, res: Response) => {
-      const { userDid, communityDid } = req.groupAuth!;
-      const rkey = req.params.rkey as string;
+      const segmentRkey = req.params.segmentRkey as string;
 
-      await opensocial.deleteCommunityRecord(
-        communityDid,
-        userDid,
-        COL_SEGMENT_PROGRESS,
-        rkey
-      );
+      const agent = await getSessionAgent(req, res, ctx);
+      if (!agent) {
+        return res.status(401).json({ error: 'Not authenticated' });
+      }
+
+      try {
+        await agent.api.com.atproto.repo.deleteRecord({
+          repo: agent.did!,
+          collection: COL_SEGMENT_PROGRESS_USER,
+          rkey: segmentRkey,
+        });
+      } catch (err: any) {
+        ctx.logger.error({ err }, 'Failed to delete segment progress from user PDS');
+        return res.status(500).json({ error: 'Failed to delete progress record' });
+      }
 
       return res.json({ success: true });
     })
@@ -1360,8 +1366,8 @@ export const createRouter = (ctx: AppContext) => {
         }
 
         if (authorDid === userDid) {
-          // User deleting their own post
-          await groupPostService.deleteGroupPost(agent, postUri);
+          // User deleting their own post — also cleans up the community postindex
+          await groupPostService.deleteGroupPost(agent, postUri, communityDid, userDid);
         } else if (isAdmin) {
           // Admin marking post as deleted
           await groupPostService.adminDeleteGroupPost(
@@ -1747,22 +1753,9 @@ export const createRouter = (ctx: AppContext) => {
       (r: any) => r.value.listItemUri === itemUri
     );
     for (const seg of itemSegments) {
-      // Delete progress records for this segment
-      const allProgress = await opensocial.listAllCommunityRecords(
-        communityDid,
-        COL_SEGMENT_PROGRESS
-      );
-      const segProgress = allProgress.filter(
-        (r: any) => r.value.segmentUri === seg.uri
-      );
-      for (const prog of segProgress) {
-        await opensocial.deleteCommunityRecord(
-          communityDid,
-          userDid,
-          COL_SEGMENT_PROGRESS,
-          rkeyFromUri(prog.uri)
-        );
-      }
+      // NOTE: Segment progress now lives in each user's personal PDS.
+      // The server cannot enumerate or delete on behalf of users.
+      // These records become stale but harmless when a segment is removed.
 
       // Delete posts for this segment
       const allPosts = await opensocial.listAllCommunityRecords(

--- a/src/routes/groupContent.ts
+++ b/src/routes/groupContent.ts
@@ -13,7 +13,11 @@
 import express, { Response } from 'express';
 import type { AppContext } from '../context';
 import { handler } from '../lib/http';
-import { requireGroupMember, requireGroupAdmin, GroupAuthRequest } from '../middleware/groupAuth';
+import {
+  requireGroupMember,
+  requireGroupAdmin,
+  GroupAuthRequest,
+} from '../middleware/groupAuth';
 import * as opensocial from '../services/opensocial';
 import { rkeyFromUri } from '../services/opensocial';
 import type { PdsRecord } from '../services/opensocial';
@@ -945,7 +949,11 @@ export const createRouter = (ctx: AppContext) => {
           collection: COL_SEGMENT_PROGRESS_USER,
           rkey: segmentRkey,
         });
-        progress = { uri: rec.data.uri, rkey: segmentRkey, ...(rec.data.value as object) };
+        progress = {
+          uri: rec.data.uri,
+          rkey: segmentRkey,
+          ...(rec.data.value as object),
+        };
       } catch {
         // No progress record yet
       }
@@ -1027,8 +1035,13 @@ export const createRouter = (ctx: AppContext) => {
           record: progressRecord as any,
         });
       } catch (err: any) {
-        ctx.logger.error({ err }, 'Failed to write segment progress to user PDS');
-        return res.status(500).json({ error: 'Failed to create progress record' });
+        ctx.logger.error(
+          { err },
+          'Failed to write segment progress to user PDS'
+        );
+        return res
+          .status(500)
+          .json({ error: 'Failed to create progress record' });
       }
 
       // ── Sync to personal progress ──────────────────────────────
@@ -1061,7 +1074,10 @@ export const createRouter = (ctx: AppContext) => {
                 headers: { 'Content-Type': 'application/json', Cookie: cookie },
                 body: JSON.stringify(syncBody),
               }).catch((err) => {
-                ctx.logger.warn({ err }, 'Failed to sync personal review segment');
+                ctx.logger.warn(
+                  { err },
+                  'Failed to sync personal review segment'
+                );
               });
 
               await fetch(`${baseUrl}/collections/quick-add`, {
@@ -1122,8 +1138,13 @@ export const createRouter = (ctx: AppContext) => {
           rkey: segmentRkey,
         });
       } catch (err: any) {
-        ctx.logger.error({ err }, 'Failed to delete segment progress from user PDS');
-        return res.status(500).json({ error: 'Failed to delete progress record' });
+        ctx.logger.error(
+          { err },
+          'Failed to delete segment progress from user PDS'
+        );
+        return res
+          .status(500)
+          .json({ error: 'Failed to delete progress record' });
       }
 
       return res.json({ success: true });
@@ -1367,7 +1388,12 @@ export const createRouter = (ctx: AppContext) => {
 
         if (authorDid === userDid) {
           // User deleting their own post — also cleans up the community postindex
-          await groupPostService.deleteGroupPost(agent, postUri, communityDid, userDid);
+          await groupPostService.deleteGroupPost(
+            agent,
+            postUri,
+            communityDid,
+            userDid
+          );
         } else if (isAdmin) {
           // Admin marking post as deleted
           await groupPostService.adminDeleteGroupPost(

--- a/src/routes/groupContent.ts
+++ b/src/routes/groupContent.ts
@@ -13,7 +13,7 @@
 import express, { Response } from 'express';
 import type { AppContext } from '../context';
 import { handler } from '../lib/http';
-import { requireGroupMember, GroupAuthRequest } from '../middleware/groupAuth';
+import { requireGroupMember, requireGroupAdmin, GroupAuthRequest } from '../middleware/groupAuth';
 import * as opensocial from '../services/opensocial';
 import { rkeyFromUri } from '../services/opensocial';
 import type { PdsRecord } from '../services/opensocial';
@@ -43,6 +43,7 @@ export const createRouter = (ctx: AppContext) => {
   // Fine-grained permission enforcement (member vs admin per collection)
   // is handled by open-social when the record write is proxied.
   const memberOnly = requireGroupMember(ctx);
+  const adminOnly = requireGroupAdmin(ctx);
 
   // ═══════════════════════════════════════════════════════════════
   // LISTS
@@ -422,13 +423,13 @@ export const createRouter = (ctx: AppContext) => {
 
   /**
    * PUT /groups/:communityDid/items/:rkey/status
-   * Set the group status of a list item. Admin only.
+   * Admin only — sets the GROUP's shared status for a list item.
    *
    * Body: { status: 'not-started' | 'in-progress' | 'completed' }
    */
   router.put(
     '/items/:rkey/status',
-    memberOnly,
+    adminOnly,
     handler(async (req: GroupAuthRequest, res: Response) => {
       const { userDid, communityDid } = req.groupAuth!;
       const rkey = req.params.rkey as string;
@@ -1012,6 +1013,7 @@ export const createRouter = (ctx: AppContext) => {
             memberDid: userDid,
             completed: true,
             completedAt: now,
+            createdAt: now,
           }
         );
       } catch (err: any) {

--- a/src/routes/groupEvents.ts
+++ b/src/routes/groupEvents.ts
@@ -1,0 +1,353 @@
+/**
+ * groupEvents.ts — routes for Events V1
+ *
+ * Mounted at /groups/:communityDid/events (via index.ts)
+ * All routes require group membership (memberOnly) or admin (adminOnly).
+ *
+ * Event records live on the community PDS (community.lexicon.calendar.event).
+ * RSVP records live on the user's own PDS (community.lexicon.calendar.rsvp).
+ * The event_rsvps Postgres table caches RSVP state for aggregation.
+ */
+
+import express, { Response } from 'express';
+import type { AppContext } from '../context';
+import { handler } from '../lib/http';
+import { requireGroupMember, requireGroupAdmin, GroupAuthRequest } from '../middleware/groupAuth';
+import { getSessionAgent } from '../auth/agent';
+import * as groupEventsService from '../services/groupEvents';
+import type { RsvpStatus } from '../services/groupEvents';
+
+const VALID_RSVP_STATUSES: RsvpStatus[] = ['going', 'interested', 'notgoing'];
+
+export const createRouter = (ctx: AppContext) => {
+  const router = express.Router({ mergeParams: true });
+
+  const memberOnly = requireGroupMember(ctx);
+  const adminOnly = requireGroupAdmin(ctx);
+
+  // ═══════════════════════════════════════════════════════════════
+  // EVENT CRUD
+  // ═══════════════════════════════════════════════════════════════
+
+  /**
+   * POST /groups/:communityDid/events
+   * Create an event. Admin only.
+   */
+  router.post(
+    '/',
+    adminOnly,
+    handler(async (req: GroupAuthRequest, res: Response) => {
+      const { userDid, communityDid } = req.groupAuth!;
+      const {
+        name,
+        description,
+        startsAt,
+        endsAt,
+        mode,
+        status,
+        locations,
+        uris,
+      } = req.body;
+
+      if (!name || typeof name !== 'string' || name.trim().length === 0) {
+        return res.status(400).json({ error: 'Event name is required' });
+      }
+
+      if (
+        mode &&
+        !['virtual', 'inperson', 'hybrid'].includes(mode)
+      ) {
+        return res.status(400).json({ error: 'Invalid mode. Use: virtual, inperson, hybrid' });
+      }
+
+      if (
+        status &&
+        !['scheduled', 'cancelled', 'postponed'].includes(status)
+      ) {
+        return res.status(400).json({
+          error: 'Invalid status. Use: scheduled, cancelled, postponed',
+        });
+      }
+
+      try {
+        const event = await groupEventsService.createEvent(
+          communityDid,
+          userDid,
+          { name: name.trim(), description, startsAt, endsAt, mode, status, locations, uris }
+        );
+        return res.status(201).json({ event });
+      } catch (err) {
+        ctx.logger.error({ err }, 'Failed to create event');
+        return res.status(500).json({ error: 'Failed to create event' });
+      }
+    })
+  );
+
+  /**
+   * GET /groups/:communityDid/events
+   * List all events with RSVP aggregates. Any member can read.
+   */
+  router.get(
+    '/',
+    memberOnly,
+    handler(async (req: GroupAuthRequest, res: Response) => {
+      const { communityDid } = req.groupAuth!;
+
+      try {
+        const events = await groupEventsService.listEvents(communityDid, ctx.db);
+        return res.json({ events });
+      } catch (err) {
+        ctx.logger.error({ err }, 'Failed to list events');
+        return res.status(500).json({ error: 'Failed to list events' });
+      }
+    })
+  );
+
+  /**
+   * GET /groups/:communityDid/events/:eventRkey
+   * Single event detail with RSVP counts.
+   */
+  router.get(
+    '/:eventRkey',
+    memberOnly,
+    handler(async (req: GroupAuthRequest, res: Response) => {
+      const { communityDid } = req.groupAuth!;
+      const eventRkey = req.params.eventRkey as string;
+
+      try {
+        const event = await groupEventsService.getEvent(communityDid, eventRkey, ctx.db);
+        if (!event) {
+          return res.status(404).json({ error: 'Event not found' });
+        }
+        return res.json({ event });
+      } catch (err) {
+        ctx.logger.error({ err }, 'Failed to get event');
+        return res.status(500).json({ error: 'Failed to get event' });
+      }
+    })
+  );
+
+  /**
+   * PUT /groups/:communityDid/events/:eventRkey
+   * Update event. Admin only.
+   */
+  router.put(
+    '/:eventRkey',
+    adminOnly,
+    handler(async (req: GroupAuthRequest, res: Response) => {
+      const { userDid, communityDid } = req.groupAuth!;
+      const eventRkey = req.params.eventRkey as string;
+      const { name, description, startsAt, endsAt, mode, status, locations, uris } = req.body;
+
+      if (
+        mode !== undefined &&
+        !['virtual', 'inperson', 'hybrid'].includes(mode)
+      ) {
+        return res.status(400).json({ error: 'Invalid mode. Use: virtual, inperson, hybrid' });
+      }
+
+      if (
+        status !== undefined &&
+        !['scheduled', 'cancelled', 'postponed'].includes(status)
+      ) {
+        return res.status(400).json({
+          error: 'Invalid status. Use: scheduled, cancelled, postponed',
+        });
+      }
+
+      try {
+        const event = await groupEventsService.updateEvent(
+          communityDid,
+          userDid,
+          eventRkey,
+          { name, description, startsAt, endsAt, mode, status, locations, uris }
+        );
+        return res.json({ event });
+      } catch (err: any) {
+        if (err?.status === 404) {
+          return res.status(404).json({ error: 'Event not found' });
+        }
+        ctx.logger.error({ err }, 'Failed to update event');
+        return res.status(500).json({ error: 'Failed to update event' });
+      }
+    })
+  );
+
+  /**
+   * DELETE /groups/:communityDid/events/:eventRkey
+   * Delete event. Admin only. Cascades event_rsvps rows.
+   */
+  router.delete(
+    '/:eventRkey',
+    adminOnly,
+    handler(async (req: GroupAuthRequest, res: Response) => {
+      const { userDid, communityDid } = req.groupAuth!;
+      const eventRkey = req.params.eventRkey as string;
+
+      // Fetch first to get the URI (needed for cascade delete)
+      const existing = await groupEventsService.getEvent(communityDid, eventRkey, ctx.db);
+      if (!existing) {
+        return res.status(404).json({ error: 'Event not found' });
+      }
+
+      try {
+        await groupEventsService.deleteEvent(
+          communityDid,
+          userDid,
+          eventRkey,
+          existing.uri,
+          ctx.db
+        );
+        return res.json({ success: true });
+      } catch (err) {
+        ctx.logger.error({ err }, 'Failed to delete event');
+        return res.status(500).json({ error: 'Failed to delete event' });
+      }
+    })
+  );
+
+  // ═══════════════════════════════════════════════════════════════
+  // RSVPs
+  // ═══════════════════════════════════════════════════════════════
+
+  /**
+   * PUT /groups/:communityDid/events/:eventRkey/rsvp
+   * Create or update an RSVP for the current user.
+   * Body: { status: 'going' | 'interested' | 'notgoing' }
+   *
+   * Server orchestrates:
+   *   1. putRecord to user's own PDS (community.lexicon.calendar.rsvp, rkey = eventRkey)
+   *   2. UPSERT into event_rsvps cache table
+   */
+  router.put(
+    '/:eventRkey/rsvp',
+    memberOnly,
+    handler(async (req: GroupAuthRequest, res: Response) => {
+      const { communityDid } = req.groupAuth!;
+      const eventRkey = req.params.eventRkey as string;
+      const { status } = req.body;
+
+      if (!status || !VALID_RSVP_STATUSES.includes(status)) {
+        return res.status(400).json({
+          error: `status must be one of: ${VALID_RSVP_STATUSES.join(', ')}`,
+        });
+      }
+
+      const agent = await getSessionAgent(req, res, ctx);
+      if (!agent) {
+        return res.status(401).json({ error: 'Not authenticated' });
+      }
+
+      const event = await groupEventsService.getEvent(communityDid, eventRkey, ctx.db);
+      if (!event) {
+        return res.status(404).json({ error: 'Event not found' });
+      }
+
+      try {
+        const { rsvpUri } = await groupEventsService.rsvpToEvent(
+          agent,
+          communityDid,
+          event.uri,
+          event.cid,
+          eventRkey,
+          status as RsvpStatus,
+          ctx.db
+        );
+        return res.json({ rsvpUri, status });
+      } catch (err) {
+        ctx.logger.error({ err }, 'Failed to RSVP to event');
+        return res.status(500).json({ error: 'Failed to RSVP to event' });
+      }
+    })
+  );
+
+  /**
+   * DELETE /groups/:communityDid/events/:eventRkey/rsvp
+   * Remove the current user's RSVP.
+   *
+   * Deletes the user-PDS record AND the event_rsvps row.
+   */
+  router.delete(
+    '/:eventRkey/rsvp',
+    memberOnly,
+    handler(async (req: GroupAuthRequest, res: Response) => {
+      const { communityDid } = req.groupAuth!;
+      const eventRkey = req.params.eventRkey as string;
+
+      const agent = await getSessionAgent(req, res, ctx);
+      if (!agent) {
+        return res.status(401).json({ error: 'Not authenticated' });
+      }
+
+      const event = await groupEventsService.getEvent(communityDid, eventRkey, ctx.db);
+      if (!event) {
+        return res.status(404).json({ error: 'Event not found' });
+      }
+
+      try {
+        await groupEventsService.removeRsvp(agent, event.uri, eventRkey, ctx.db);
+        return res.json({ success: true });
+      } catch (err) {
+        ctx.logger.error({ err }, 'Failed to remove RSVP');
+        return res.status(500).json({ error: 'Failed to remove RSVP' });
+      }
+    })
+  );
+
+  /**
+   * GET /groups/:communityDid/events/:eventRkey/rsvps
+   * Paginated attendee list, optionally filtered by status.
+   *
+   * Query params:
+   *   status  — 'going' | 'interested' | 'notgoing' (optional)
+   *   limit   — number (default 50, max 100)
+   *   offset  — number (default 0)
+   */
+  router.get(
+    '/:eventRkey/rsvps',
+    memberOnly,
+    handler(async (req: GroupAuthRequest, res: Response) => {
+      const { communityDid } = req.groupAuth!;
+      const eventRkey = req.params.eventRkey as string;
+      const statusFilter = req.query.status as RsvpStatus | undefined;
+      const limit = Math.min(parseInt(req.query.limit as string) || 50, 100);
+      const offset = parseInt(req.query.offset as string) || 0;
+
+      if (statusFilter && !VALID_RSVP_STATUSES.includes(statusFilter)) {
+        return res.status(400).json({
+          error: `status must be one of: ${VALID_RSVP_STATUSES.join(', ')}`,
+        });
+      }
+
+      const event = await groupEventsService.getEvent(communityDid, eventRkey, ctx.db);
+      if (!event) {
+        return res.status(404).json({ error: 'Event not found' });
+      }
+
+      try {
+        const { rows, total } = await groupEventsService.listRsvps(
+          event.uri,
+          ctx.db,
+          { status: statusFilter, limit, offset }
+        );
+
+        return res.json({
+          rsvps: rows.map((r) => ({
+            userDid: r.user_did,
+            status: r.status.split('#')[1], // short form for clients
+            rsvpUri: r.rsvp_uri,
+            rsvpAt: r.rsvp_at,
+          })),
+          total,
+          limit,
+          offset,
+        });
+      } catch (err) {
+        ctx.logger.error({ err }, 'Failed to list RSVPs');
+        return res.status(500).json({ error: 'Failed to list RSVPs' });
+      }
+    })
+  );
+
+  return router;
+};

--- a/src/routes/groupEvents.ts
+++ b/src/routes/groupEvents.ts
@@ -12,7 +12,11 @@
 import express, { Response } from 'express';
 import type { AppContext } from '../context';
 import { handler } from '../lib/http';
-import { requireGroupMember, requireGroupAdmin, GroupAuthRequest } from '../middleware/groupAuth';
+import {
+  requireGroupMember,
+  requireGroupAdmin,
+  GroupAuthRequest,
+} from '../middleware/groupAuth';
 import { getSessionAgent } from '../auth/agent';
 import * as groupEventsService from '../services/groupEvents';
 import type { RsvpStatus } from '../services/groupEvents';
@@ -53,17 +57,13 @@ export const createRouter = (ctx: AppContext) => {
         return res.status(400).json({ error: 'Event name is required' });
       }
 
-      if (
-        mode &&
-        !['virtual', 'inperson', 'hybrid'].includes(mode)
-      ) {
-        return res.status(400).json({ error: 'Invalid mode. Use: virtual, inperson, hybrid' });
+      if (mode && !['virtual', 'inperson', 'hybrid'].includes(mode)) {
+        return res
+          .status(400)
+          .json({ error: 'Invalid mode. Use: virtual, inperson, hybrid' });
       }
 
-      if (
-        status &&
-        !['scheduled', 'cancelled', 'postponed'].includes(status)
-      ) {
+      if (status && !['scheduled', 'cancelled', 'postponed'].includes(status)) {
         return res.status(400).json({
           error: 'Invalid status. Use: scheduled, cancelled, postponed',
         });
@@ -73,7 +73,16 @@ export const createRouter = (ctx: AppContext) => {
         const event = await groupEventsService.createEvent(
           communityDid,
           userDid,
-          { name: name.trim(), description, startsAt, endsAt, mode, status, locations, uris }
+          {
+            name: name.trim(),
+            description,
+            startsAt,
+            endsAt,
+            mode,
+            status,
+            locations,
+            uris,
+          }
         );
         return res.status(201).json({ event });
       } catch (err) {
@@ -94,7 +103,10 @@ export const createRouter = (ctx: AppContext) => {
       const { communityDid } = req.groupAuth!;
 
       try {
-        const events = await groupEventsService.listEvents(communityDid, ctx.db);
+        const events = await groupEventsService.listEvents(
+          communityDid,
+          ctx.db
+        );
         return res.json({ events });
       } catch (err) {
         ctx.logger.error({ err }, 'Failed to list events');
@@ -115,7 +127,11 @@ export const createRouter = (ctx: AppContext) => {
       const eventRkey = req.params.eventRkey as string;
 
       try {
-        const event = await groupEventsService.getEvent(communityDid, eventRkey, ctx.db);
+        const event = await groupEventsService.getEvent(
+          communityDid,
+          eventRkey,
+          ctx.db
+        );
         if (!event) {
           return res.status(404).json({ error: 'Event not found' });
         }
@@ -137,13 +153,24 @@ export const createRouter = (ctx: AppContext) => {
     handler(async (req: GroupAuthRequest, res: Response) => {
       const { userDid, communityDid } = req.groupAuth!;
       const eventRkey = req.params.eventRkey as string;
-      const { name, description, startsAt, endsAt, mode, status, locations, uris } = req.body;
+      const {
+        name,
+        description,
+        startsAt,
+        endsAt,
+        mode,
+        status,
+        locations,
+        uris,
+      } = req.body;
 
       if (
         mode !== undefined &&
         !['virtual', 'inperson', 'hybrid'].includes(mode)
       ) {
-        return res.status(400).json({ error: 'Invalid mode. Use: virtual, inperson, hybrid' });
+        return res
+          .status(400)
+          .json({ error: 'Invalid mode. Use: virtual, inperson, hybrid' });
       }
 
       if (
@@ -185,7 +212,11 @@ export const createRouter = (ctx: AppContext) => {
       const eventRkey = req.params.eventRkey as string;
 
       // Fetch first to get the URI (needed for cascade delete)
-      const existing = await groupEventsService.getEvent(communityDid, eventRkey, ctx.db);
+      const existing = await groupEventsService.getEvent(
+        communityDid,
+        eventRkey,
+        ctx.db
+      );
       if (!existing) {
         return res.status(404).json({ error: 'Event not found' });
       }
@@ -238,7 +269,11 @@ export const createRouter = (ctx: AppContext) => {
         return res.status(401).json({ error: 'Not authenticated' });
       }
 
-      const event = await groupEventsService.getEvent(communityDid, eventRkey, ctx.db);
+      const event = await groupEventsService.getEvent(
+        communityDid,
+        eventRkey,
+        ctx.db
+      );
       if (!event) {
         return res.status(404).json({ error: 'Event not found' });
       }
@@ -279,13 +314,22 @@ export const createRouter = (ctx: AppContext) => {
         return res.status(401).json({ error: 'Not authenticated' });
       }
 
-      const event = await groupEventsService.getEvent(communityDid, eventRkey, ctx.db);
+      const event = await groupEventsService.getEvent(
+        communityDid,
+        eventRkey,
+        ctx.db
+      );
       if (!event) {
         return res.status(404).json({ error: 'Event not found' });
       }
 
       try {
-        await groupEventsService.removeRsvp(agent, event.uri, eventRkey, ctx.db);
+        await groupEventsService.removeRsvp(
+          agent,
+          event.uri,
+          eventRkey,
+          ctx.db
+        );
         return res.json({ success: true });
       } catch (err) {
         ctx.logger.error({ err }, 'Failed to remove RSVP');
@@ -319,7 +363,11 @@ export const createRouter = (ctx: AppContext) => {
         });
       }
 
-      const event = await groupEventsService.getEvent(communityDid, eventRkey, ctx.db);
+      const event = await groupEventsService.getEvent(
+        communityDid,
+        eventRkey,
+        ctx.db
+      );
       if (!event) {
         return res.status(404).json({ error: 'Event not found' });
       }

--- a/src/routes/reviewSegments.ts
+++ b/src/routes/reviewSegments.ts
@@ -307,7 +307,9 @@ export const createRouter = (ctx: AppContext) => {
       }
 
       try {
-        const listItemUri = decodeURIComponent(req.params.listItemUri as string);
+        const listItemUri = decodeURIComponent(
+          req.params.listItemUri as string
+        );
 
         // Get all review segments from the user's repo
         const response = await agent.api.com.atproto.repo.listRecords({

--- a/src/routes/share.ts
+++ b/src/routes/share.ts
@@ -22,12 +22,16 @@ export const createRouter = (ctx: AppContext) => {
         return res.status(401).json({ error: 'Not authenticated' });
       }
 
-      const { mediaItemId, mediaType, collectionUri, reviewId, goalUri } = req.body;
+      const { mediaItemId, mediaType, collectionUri, reviewId, goalUri } =
+        req.body;
 
       // Validate: must provide either media item, collection, review, or goal, not multiple
-      const providedTypes = [mediaItemId, collectionUri, reviewId, goalUri].filter(
-        Boolean
-      ).length;
+      const providedTypes = [
+        mediaItemId,
+        collectionUri,
+        reviewId,
+        goalUri,
+      ].filter(Boolean).length;
       if (providedTypes === 0) {
         return res.status(400).json({
           error:
@@ -257,9 +261,9 @@ export const createRouter = (ctx: AppContext) => {
         !shareType ||
         !['item', 'collection', 'review', 'goal'].includes(shareType)
       ) {
-        return res
-          .status(400)
-          .json({ error: 'shareType must be item, collection, review, or goal' });
+        return res.status(400).json({
+          error: 'shareType must be item, collection, review, or goal',
+        });
       }
 
       try {
@@ -431,14 +435,31 @@ export const createRouter = (ctx: AppContext) => {
           // Fetch goal details for Open Graph tags
           const goal = await ctx.db
             .selectFrom('goals')
-            .select(['title', 'mediaType', 'targetCount', 'cachedCompletedCount', 'startDate', 'endDate'])
+            .select([
+              'title',
+              'mediaType',
+              'targetCount',
+              'cachedCompletedCount',
+              'startDate',
+              'endDate',
+            ])
             .where('uri', '=', shareLink.goalUri)
             .executeTakeFirst();
 
           if (goal) {
-            const pct = Math.min(100, Math.round((goal.cachedCompletedCount / goal.targetCount) * 100));
+            const pct = Math.min(
+              100,
+              Math.round((goal.cachedCompletedCount / goal.targetCount) * 100)
+            );
             const mediaLabel = goal.mediaType || 'items';
-            const emoji = goal.mediaType === 'book' ? '📚' : goal.mediaType === 'movie' ? '🎬' : goal.mediaType === 'tv' ? '📺' : '🎯';
+            const emoji =
+              goal.mediaType === 'book'
+                ? '📚'
+                : goal.mediaType === 'movie'
+                  ? '🎬'
+                  : goal.mediaType === 'tv'
+                    ? '📺'
+                    : '🎯';
             title = escapeHtml(`${emoji} ${goal.title}`);
             description = escapeHtml(
               `${goal.cachedCompletedCount} of ${goal.targetCount} ${mediaLabel} completed (${pct}%)`

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -61,7 +61,9 @@ export const createRouter = (ctx: AppContext) => {
     }
 
     try {
-      const handle = Array.isArray(req.params.handle) ? req.params.handle[0] : req.params.handle;
+      const handle = Array.isArray(req.params.handle)
+        ? req.params.handle[0]
+        : req.params.handle;
       const profile = await agent.getProfile({ actor: handle });
 
       // Get collection count

--- a/src/services/groupEvents.ts
+++ b/src/services/groupEvents.ts
@@ -1,0 +1,374 @@
+/**
+ * groupEvents.ts — service layer for Events V1
+ *
+ * Events are group-owned records stored on the community PDS:
+ *   collection: 'community.lexicon.calendar.event'
+ *
+ * RSVPs are user-owned records stored on the user's own PDS:
+ *   collection: 'community.lexicon.calendar.rsvp'
+ *
+ * The `event_rsvps` Postgres table caches RSVP state for aggregation
+ * (counts, attendee lists, community-level queries).
+ *
+ * Token format (per Simon's canonical shapes — simon-event-lexicon-shapes.md):
+ *   mode:   "community.lexicon.calendar.event#virtual"   ← full NSID + fragment
+ *   status: "community.lexicon.calendar.event#scheduled"
+ *   rsvp:   "community.lexicon.calendar.rsvp#going"
+ */
+
+import { Agent } from '@atproto/api';
+import { TID } from '@atproto/common';
+import type { Kysely } from 'kysely';
+import * as opensocial from './opensocial';
+
+const COL_EVENT = 'community.lexicon.calendar.event';
+const COL_RSVP = 'community.lexicon.calendar.rsvp';
+
+export type RsvpStatus = 'going' | 'interested' | 'notgoing';
+
+export interface EventRecord {
+  uri: string;
+  cid: string;
+  rkey: string;
+  name: string;
+  description?: string;
+  startsAt?: string;
+  endsAt?: string;
+  mode?: string;
+  status?: string;
+  locations?: Array<{
+    name?: string;
+    locality?: string;
+    region?: string;
+    country?: string;
+    latitude?: number;
+    longitude?: number;
+  }>;
+  uris?: Array<{ uri: string; name?: string }>;
+  createdAt: string;
+}
+
+export interface RsvpRow {
+  event_uri: string;
+  event_cid: string;
+  community_did: string;
+  user_did: string;
+  rsvp_uri: string;
+  status: string;
+  rsvp_at: Date;
+  updated_at: Date;
+}
+
+/** Map the raw RSVP status string to the full token. */
+function rsvpStatusToken(status: RsvpStatus): string {
+  return `${COL_RSVP}#${status}`;
+}
+
+/** Parse a stored token back to the short status. */
+function parseRsvpStatus(token: string): RsvpStatus {
+  const fragment = token.split('#')[1];
+  return fragment as RsvpStatus;
+}
+
+// ─── Events ────────────────────────────────────────────────────────────────
+
+export async function createEvent(
+  communityDid: string,
+  userDid: string,
+  data: {
+    name: string;
+    description?: string;
+    startsAt?: string;
+    endsAt?: string;
+    mode?: 'virtual' | 'inperson' | 'hybrid';
+    status?: 'scheduled' | 'cancelled' | 'postponed';
+    locations?: EventRecord['locations'];
+    uris?: EventRecord['uris'];
+  }
+): Promise<EventRecord> {
+  const rkey = TID.nextStr();
+  const now = new Date().toISOString();
+
+  const record: Record<string, unknown> = {
+
+    name: data.name,
+    createdAt: now,
+  };
+  if (data.description) record.description = data.description;
+  if (data.startsAt) record.startsAt = data.startsAt;
+  if (data.endsAt) record.endsAt = data.endsAt;
+  if (data.mode) record.mode = `${COL_EVENT}#${data.mode}`;
+  if (data.status) record.status = `${COL_EVENT}#${data.status}`;
+  else record.status = `${COL_EVENT}#scheduled`;
+  if (data.locations?.length) record.locations = data.locations;
+  if (data.uris?.length) record.uris = data.uris;
+
+  const response = await opensocial.createCommunityRecord(
+    communityDid,
+    userDid,
+    COL_EVENT,
+    record,
+    rkey
+  );
+
+  return {
+    uri: response.uri,
+    cid: response.cid,
+    rkey,
+    name: data.name,
+    description: data.description,
+    startsAt: data.startsAt,
+    endsAt: data.endsAt,
+    mode: data.mode ? `${COL_EVENT}#${data.mode}` : undefined,
+    status: data.status ? `${COL_EVENT}#${data.status}` : `${COL_EVENT}#scheduled`,
+    locations: data.locations,
+    uris: data.uris,
+    createdAt: now,
+  };
+}
+
+export async function listEvents(
+  communityDid: string,
+  db: Kysely<any>
+): Promise<Array<EventRecord & { rsvpCounts: Record<RsvpStatus, number> }>> {
+  const rawEvents = await opensocial.listAllCommunityRecords(communityDid, COL_EVENT);
+
+  // Batch fetch RSVP counts for all events
+  const eventUris = rawEvents.map((e: any) => e.uri);
+  const rsvpRows = eventUris.length
+    ? await db
+        .selectFrom('event_rsvps')
+        .select(['event_uri', 'status'])
+        .where('event_uri', 'in', eventUris)
+        .execute()
+    : [];
+
+  const countsByEvent: Record<string, Record<string, number>> = {};
+  for (const row of rsvpRows) {
+    const shortStatus = parseRsvpStatus(row.status);
+    if (!countsByEvent[row.event_uri]) {
+      countsByEvent[row.event_uri] = { going: 0, interested: 0, notgoing: 0 };
+    }
+    countsByEvent[row.event_uri][shortStatus] =
+      (countsByEvent[row.event_uri][shortStatus] ?? 0) + 1;
+  }
+
+  return rawEvents.map((e: any) => {
+    const rkey = e.uri.split('/').at(-1)!;
+    const counts = countsByEvent[e.uri] ?? { going: 0, interested: 0, notgoing: 0 };
+    return {
+      uri: e.uri,
+      cid: e.cid,
+      rkey,
+      ...e.value,
+      rsvpCounts: counts as Record<RsvpStatus, number>,
+    };
+  });
+}
+
+export async function getEvent(
+  communityDid: string,
+  eventRkey: string,
+  db: Kysely<any>
+): Promise<(EventRecord & { rsvpCounts: Record<RsvpStatus, number> }) | null> {
+  let record: any;
+  try {
+    record = await opensocial.getCommunityRecord(communityDid, COL_EVENT, eventRkey);
+  } catch {
+    return null;
+  }
+
+  const rsvpRows = await db
+    .selectFrom('event_rsvps')
+    .select(['status'])
+    .where('event_uri', '=', record.uri)
+    .execute();
+
+  const counts: Record<string, number> = { going: 0, interested: 0, notgoing: 0 };
+  for (const row of rsvpRows) {
+    const shortStatus = parseRsvpStatus(row.status);
+    counts[shortStatus] = (counts[shortStatus] ?? 0) + 1;
+  }
+
+  return {
+    uri: record.uri,
+    cid: record.cid,
+    rkey: eventRkey,
+    ...record.value,
+    rsvpCounts: counts as Record<RsvpStatus, number>,
+  };
+}
+
+export async function updateEvent(
+  communityDid: string,
+  userDid: string,
+  eventRkey: string,
+  data: Partial<{
+    name: string;
+    description: string;
+    startsAt: string;
+    endsAt: string;
+    mode: 'virtual' | 'inperson' | 'hybrid';
+    status: 'scheduled' | 'cancelled' | 'postponed';
+    locations: EventRecord['locations'];
+    uris: EventRecord['uris'];
+  }>
+): Promise<EventRecord> {
+  const existing = await opensocial.getCommunityRecord(communityDid, COL_EVENT, eventRkey);
+  const merged: Record<string, unknown> = { ...(existing.value as object) };
+
+  if (data.name !== undefined) merged.name = data.name;
+  if (data.description !== undefined) merged.description = data.description;
+  if (data.startsAt !== undefined) merged.startsAt = data.startsAt;
+  if (data.endsAt !== undefined) merged.endsAt = data.endsAt;
+  if (data.mode !== undefined) merged.mode = `${COL_EVENT}#${data.mode}`;
+  if (data.status !== undefined) merged.status = `${COL_EVENT}#${data.status}`;
+  if (data.locations !== undefined) merged.locations = data.locations;
+  if (data.uris !== undefined) merged.uris = data.uris;
+
+  await opensocial.updateCommunityRecord(
+    communityDid,
+    userDid,
+    COL_EVENT,
+    eventRkey,
+    merged
+  );
+
+  return {
+    uri: existing.uri,
+    cid: existing.cid,
+    rkey: eventRkey,
+    ...(merged as Omit<EventRecord, 'uri' | 'cid' | 'rkey'>),
+  };
+}
+
+export async function deleteEvent(
+  communityDid: string,
+  userDid: string,
+  eventRkey: string,
+  eventUri: string,
+  db: Kysely<any>
+): Promise<void> {
+  // 1. Delete community PDS record
+  await opensocial.deleteCommunityRecord(communityDid, userDid, COL_EVENT, eventRkey);
+
+  // 2. Cascade-delete RSVP cache rows
+  await db.deleteFrom('event_rsvps').where('event_uri', '=', eventUri).execute();
+}
+
+// ─── RSVPs ─────────────────────────────────────────────────────────────────
+
+export async function rsvpToEvent(
+  agent: Agent,
+  communityDid: string,
+  eventUri: string,
+  eventCid: string,
+  eventRkey: string,
+  status: RsvpStatus,
+  db: Kysely<any>
+): Promise<{ rsvpUri: string }> {
+  const rsvpRecord = {
+    $type: COL_RSVP,
+    subject: {
+      uri: eventUri,
+      cid: eventCid,
+    },
+    status: rsvpStatusToken(status),
+  };
+
+  // 1. Write RSVP to user's own PDS (idempotent putRecord; rkey = eventRkey)
+  const response = await agent.api.com.atproto.repo.putRecord({
+    repo: agent.did!,
+    collection: COL_RSVP,
+    rkey: eventRkey,
+    record: rsvpRecord as any,
+  });
+
+  // 2. Upsert into event_rsvps cache
+  const now = new Date();
+  await (db as any)
+    .insertInto('event_rsvps')
+    .values({
+      event_uri: eventUri,
+      event_cid: eventCid,
+      community_did: communityDid,
+      user_did: agent.did!,
+      rsvp_uri: response.data.uri,
+      status: rsvpStatusToken(status),
+      rsvp_at: now,
+      updated_at: now,
+    })
+    .onConflict((oc: any) =>
+      oc
+        .columns(['event_uri', 'user_did'])
+        .doUpdateSet({
+          status: rsvpStatusToken(status),
+          rsvp_uri: response.data.uri,
+          updated_at: now,
+        })
+    )
+    .execute();
+
+  return { rsvpUri: response.data.uri };
+}
+
+export async function removeRsvp(
+  agent: Agent,
+  eventUri: string,
+  eventRkey: string,
+  db: Kysely<any>
+): Promise<void> {
+  // 1. Delete from user's own PDS
+  try {
+    await agent.api.com.atproto.repo.deleteRecord({
+      repo: agent.did!,
+      collection: COL_RSVP,
+      rkey: eventRkey,
+    });
+  } catch (err: any) {
+    // If already deleted from PDS, still clean up the DB row
+    if (!err?.status || err.status !== 404) throw err;
+  }
+
+  // 2. Remove from cache
+  await db
+    .deleteFrom('event_rsvps')
+    .where('event_uri', '=', eventUri)
+    .where('user_did', '=', agent.did!)
+    .execute();
+}
+
+export async function listRsvps(
+  eventUri: string,
+  db: Kysely<any>,
+  opts: {
+    status?: RsvpStatus;
+    limit?: number;
+    offset?: number;
+  } = {}
+): Promise<{ rows: RsvpRow[]; total: number }> {
+  const limit = opts.limit ?? 50;
+  const offset = opts.offset ?? 0;
+
+  let query = db.selectFrom('event_rsvps').selectAll().where('event_uri', '=', eventUri);
+  let countQuery = db
+    .selectFrom('event_rsvps')
+    .select(({ fn }: any) => [fn.countAll().as('count')])
+    .where('event_uri', '=', eventUri);
+
+  if (opts.status) {
+    const token = rsvpStatusToken(opts.status);
+    query = query.where('status', '=', token);
+    countQuery = countQuery.where('status', '=', token);
+  }
+
+  const [rows, countRow] = await Promise.all([
+    query.orderBy('rsvp_at', 'asc').limit(limit).offset(offset).execute(),
+    countQuery.executeTakeFirst(),
+  ]);
+
+  return {
+    rows: rows as RsvpRow[],
+    total: parseInt((countRow as any)?.count ?? '0', 10),
+  };
+}

--- a/src/services/groupEvents.ts
+++ b/src/services/groupEvents.ts
@@ -90,7 +90,6 @@ export async function createEvent(
   const now = new Date().toISOString();
 
   const record: Record<string, unknown> = {
-
     name: data.name,
     createdAt: now,
   };
@@ -120,7 +119,9 @@ export async function createEvent(
     startsAt: data.startsAt,
     endsAt: data.endsAt,
     mode: data.mode ? `${COL_EVENT}#${data.mode}` : undefined,
-    status: data.status ? `${COL_EVENT}#${data.status}` : `${COL_EVENT}#scheduled`,
+    status: data.status
+      ? `${COL_EVENT}#${data.status}`
+      : `${COL_EVENT}#scheduled`,
     locations: data.locations,
     uris: data.uris,
     createdAt: now,
@@ -131,7 +132,10 @@ export async function listEvents(
   communityDid: string,
   db: Kysely<any>
 ): Promise<Array<EventRecord & { rsvpCounts: Record<RsvpStatus, number> }>> {
-  const rawEvents = await opensocial.listAllCommunityRecords(communityDid, COL_EVENT);
+  const rawEvents = await opensocial.listAllCommunityRecords(
+    communityDid,
+    COL_EVENT
+  );
 
   // Batch fetch RSVP counts for all events
   const eventUris = rawEvents.map((e: any) => e.uri);
@@ -155,7 +159,11 @@ export async function listEvents(
 
   return rawEvents.map((e: any) => {
     const rkey = e.uri.split('/').at(-1)!;
-    const counts = countsByEvent[e.uri] ?? { going: 0, interested: 0, notgoing: 0 };
+    const counts = countsByEvent[e.uri] ?? {
+      going: 0,
+      interested: 0,
+      notgoing: 0,
+    };
     return {
       uri: e.uri,
       cid: e.cid,
@@ -173,7 +181,11 @@ export async function getEvent(
 ): Promise<(EventRecord & { rsvpCounts: Record<RsvpStatus, number> }) | null> {
   let record: any;
   try {
-    record = await opensocial.getCommunityRecord(communityDid, COL_EVENT, eventRkey);
+    record = await opensocial.getCommunityRecord(
+      communityDid,
+      COL_EVENT,
+      eventRkey
+    );
   } catch {
     return null;
   }
@@ -184,7 +196,11 @@ export async function getEvent(
     .where('event_uri', '=', record.uri)
     .execute();
 
-  const counts: Record<string, number> = { going: 0, interested: 0, notgoing: 0 };
+  const counts: Record<string, number> = {
+    going: 0,
+    interested: 0,
+    notgoing: 0,
+  };
   for (const row of rsvpRows) {
     const shortStatus = parseRsvpStatus(row.status);
     counts[shortStatus] = (counts[shortStatus] ?? 0) + 1;
@@ -214,7 +230,11 @@ export async function updateEvent(
     uris: EventRecord['uris'];
   }>
 ): Promise<EventRecord> {
-  const existing = await opensocial.getCommunityRecord(communityDid, COL_EVENT, eventRkey);
+  const existing = await opensocial.getCommunityRecord(
+    communityDid,
+    COL_EVENT,
+    eventRkey
+  );
   const merged: Record<string, unknown> = { ...(existing.value as object) };
 
   if (data.name !== undefined) merged.name = data.name;
@@ -250,10 +270,18 @@ export async function deleteEvent(
   db: Kysely<any>
 ): Promise<void> {
   // 1. Delete community PDS record
-  await opensocial.deleteCommunityRecord(communityDid, userDid, COL_EVENT, eventRkey);
+  await opensocial.deleteCommunityRecord(
+    communityDid,
+    userDid,
+    COL_EVENT,
+    eventRkey
+  );
 
   // 2. Cascade-delete RSVP cache rows
-  await db.deleteFrom('event_rsvps').where('event_uri', '=', eventUri).execute();
+  await db
+    .deleteFrom('event_rsvps')
+    .where('event_uri', '=', eventUri)
+    .execute();
 }
 
 // ─── RSVPs ─────────────────────────────────────────────────────────────────
@@ -299,13 +327,11 @@ export async function rsvpToEvent(
       updated_at: now,
     })
     .onConflict((oc: any) =>
-      oc
-        .columns(['event_uri', 'user_did'])
-        .doUpdateSet({
-          status: rsvpStatusToken(status),
-          rsvp_uri: response.data.uri,
-          updated_at: now,
-        })
+      oc.columns(['event_uri', 'user_did']).doUpdateSet({
+        status: rsvpStatusToken(status),
+        rsvp_uri: response.data.uri,
+        updated_at: now,
+      })
     )
     .execute();
 
@@ -350,7 +376,10 @@ export async function listRsvps(
   const limit = opts.limit ?? 50;
   const offset = opts.offset ?? 0;
 
-  let query = db.selectFrom('event_rsvps').selectAll().where('event_uri', '=', eventUri);
+  let query = db
+    .selectFrom('event_rsvps')
+    .selectAll()
+    .where('event_uri', '=', eventUri);
   let countQuery = db
     .selectFrom('event_rsvps')
     .select(({ fn }: any) => [fn.countAll().as('count')])

--- a/src/services/groupPosts.ts
+++ b/src/services/groupPosts.ts
@@ -65,9 +65,12 @@ export async function createGroupPost(
     record: postRecord as any,
   });
 
-  // 2. Create index entry in community repo
+  // 2. Create index entry in community repo with a strongRef (post.uri + post.cid)
   const indexRecord = {
-    postUri: postResponse.data.uri,
+    post: {
+      uri: postResponse.data.uri,
+      cid: postResponse.data.cid,
+    },
     authorDid: userDid,
     segmentUri: data.segmentUri || undefined,
     listItemUri: data.listItemUri || undefined,
@@ -118,7 +121,7 @@ export async function fetchGroupPosts(
   await Promise.all(
     relevantIndexes.map(async (idx: any) => {
       try {
-        const postUri = idx.value.postUri;
+        const postUri = idx.value.post.uri;
         const match = postUri.match(/at:\/\/([^\/]+)\/([^\/]+)\/(.+)/);
         if (!match) return;
 
@@ -136,7 +139,7 @@ export async function fetchGroupPosts(
           authorDid: ownerDid,
         });
       } catch (err) {
-        console.warn(`Failed to fetch post ${idx.value.postUri}:`, err);
+        console.warn(`Failed to fetch post ${idx.value.post?.uri}:`, err);
         // Post may be deleted or repo unavailable - skip it
       }
     })
@@ -211,11 +214,15 @@ export function buildThreads(posts: GroupPost[]): GroupPost[] {
 }
 
 /**
- * Delete a post (user-initiated)
+ * Delete a post (user-initiated).
+ * Removes the post from the user's personal repo and cleans up the orphaned
+ * postindex pointer in the community repo (A.4).
  */
 export async function deleteGroupPost(
   agent: Agent,
-  postUri: string
+  postUri: string,
+  communityDid: string,
+  userDid: string
 ): Promise<void> {
   const match = postUri.match(/at:\/\/([^\/]+)\/([^\/]+)\/(.+)/);
   if (!match) throw new Error('Invalid post URI');
@@ -226,11 +233,39 @@ export async function deleteGroupPost(
     throw new Error('You can only delete your own posts');
   }
 
+  // 1. Delete from user's personal PDS
   await agent.api.com.atproto.repo.deleteRecord({
     repo: agent.did!,
     collection: collection,
     rkey: rkey,
   });
+
+  // 2. Find and delete the postindex pointer from the community repo
+  try {
+    const allIndexes = await opensocial.listAllCommunityRecords(
+      communityDid,
+      COL_POST_INDEX
+    );
+    const indexEntry = allIndexes.find(
+      (idx: any) => idx.value.post?.uri === postUri
+    );
+    if (indexEntry) {
+      const indexRkey = indexEntry.uri.split('/').pop()!;
+      await opensocial.deleteCommunityRecord(
+        communityDid,
+        userDid,
+        COL_POST_INDEX,
+        indexRkey
+      );
+    }
+  } catch (err) {
+    console.warn(
+      `Failed to clean up postindex for ${postUri} — pointer may be orphaned:`,
+      err
+    );
+    // Non-fatal: the user-PDS record is already gone; the stale pointer will
+    // be silently skipped by fetchGroupPosts (getRecord will 404 and be dropped).
+  }
 }
 
 /**
@@ -248,7 +283,7 @@ export async function adminDeleteGroupPost(
   );
 
   const indexEntry = allIndexes.find(
-    (idx: any) => idx.value.postUri === postUri
+    (idx: any) => idx.value.post?.uri === postUri
   );
   if (!indexEntry) {
     throw new Error('Post index not found');

--- a/src/services/groupPosts.ts
+++ b/src/services/groupPosts.ts
@@ -259,8 +259,11 @@ export async function deleteGroupPost(
       );
     }
   } catch (err) {
+    // Pass postUri as structured data rather than interpolating into the message
+    // to avoid CodeQL CWE-134 (externally-controlled format string).
     console.warn(
-      `Failed to clean up postindex for ${postUri} — pointer may be orphaned:`,
+      'Failed to clean up postindex — pointer may be orphaned:',
+      { postUri },
       err
     );
     // Non-fatal: the user-PDS record is already gone; the stale pointer will

--- a/src/services/opensocial.ts
+++ b/src/services/opensocial.ts
@@ -530,6 +530,14 @@ export async function resolveUserPermissions(
       u: 'member',
       d: 'member',
     },
+    // Events are created/updated/deleted by admins; all members can read.
+    // RSVPs are user-PDS records and are NOT in DEFAULTS (OpenSocial is not in that path).
+    'community.lexicon.calendar.event': {
+      c: 'admin',
+      r: 'member',
+      u: 'admin',
+      d: 'admin',
+    },
   };
 
   const result: Record<string, ResolvedCollectionPermission> = {};

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,4 +1,3 @@
 // Express v5 types params as `string | string[]` to account for wildcard routes.
 // This project only uses named params (e.g., /:id), which are always strings.
 // We provide a helper type and recommend `as string` casts at usage sites.
-

--- a/test/groupAuth.test.ts
+++ b/test/groupAuth.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Response, NextFunction } from 'express';
+import { requireGroupMember, requireGroupAdmin, type GroupAuthRequest } from '../src/middleware/groupAuth';
+
+// Mock the entire opensocial service so no real HTTP calls are made.
+vi.mock('../src/services/opensocial', () => ({
+  checkMembership: vi.fn(),
+}));
+
+// Mock getSessionAgent so tests don't need a real database / cookie session.
+vi.mock('../src/auth/agent', () => ({
+  getSessionAgent: vi.fn(),
+}));
+
+import * as opensocial from '../src/services/opensocial';
+import { getSessionAgent } from '../src/auth/agent';
+
+const mockCheckMembership = vi.mocked(opensocial.checkMembership);
+const mockGetSessionAgent = vi.mocked(getSessionAgent);
+
+// Minimal AppContext — the middleware only uses it to pass to getSessionAgent.
+const ctx = {} as any;
+
+function makeReqRes(params: Record<string, string> = {}) {
+  const req: Partial<GroupAuthRequest> = { params };
+  const json = vi.fn();
+  const status = vi.fn().mockReturnValue({ json });
+  const res = { status, json } as unknown as Response;
+  const next: NextFunction = vi.fn();
+  return { req: req as GroupAuthRequest, res, next, json, status };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── requireGroupMember ────────────────────────────────────────────
+
+describe('requireGroupMember', () => {
+  it('returns 401 when there is no active session', async () => {
+    mockGetSessionAgent.mockResolvedValue(null as any);
+    const { req, res, next, status, json } = makeReqRes({ communityDid: 'did:plc:community1' });
+
+    await requireGroupMember(ctx)(req, res, next);
+
+    expect(status).toHaveBeenCalledWith(401);
+    expect(json).toHaveBeenCalledWith(expect.objectContaining({ error: expect.stringContaining('authenticated') }));
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when communityDid param is missing', async () => {
+    mockGetSessionAgent.mockResolvedValue({ did: 'did:plc:user1' } as any);
+    const { req, res, next, status, json } = makeReqRes({}); // no communityDid
+
+    await requireGroupMember(ctx)(req, res, next);
+
+    expect(status).toHaveBeenCalledWith(400);
+    expect(json).toHaveBeenCalledWith(expect.objectContaining({ error: expect.stringContaining('communityDid') }));
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when checkMembership returns isMember: false', async () => {
+    mockGetSessionAgent.mockResolvedValue({ did: 'did:plc:user1' } as any);
+    mockCheckMembership.mockResolvedValue({ isMember: false, isAdmin: false });
+    const { req, res, next, status } = makeReqRes({ communityDid: 'did:plc:community1' });
+
+    await requireGroupMember(ctx)(req, res, next);
+
+    expect(status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('calls next() and attaches groupAuth when user is a member', async () => {
+    mockGetSessionAgent.mockResolvedValue({ did: 'did:plc:user1' } as any);
+    mockCheckMembership.mockResolvedValue({ isMember: true, isAdmin: false });
+    const { req, res, next } = makeReqRes({ communityDid: 'did:plc:community1' });
+
+    await requireGroupMember(ctx)(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(req.groupAuth).toMatchObject({
+      userDid: 'did:plc:user1',
+      communityDid: 'did:plc:community1',
+      isMember: true,
+      isAdmin: false,
+    });
+  });
+
+  it('calls next() and marks isAdmin when user is an admin', async () => {
+    mockGetSessionAgent.mockResolvedValue({ did: 'did:plc:admin1' } as any);
+    mockCheckMembership.mockResolvedValue({ isMember: true, isAdmin: true });
+    const { req, res, next } = makeReqRes({ communityDid: 'did:plc:community1' });
+
+    await requireGroupMember(ctx)(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(req.groupAuth?.isAdmin).toBe(true);
+  });
+});
+
+// ── requireGroupAdmin ─────────────────────────────────────────────
+
+describe('requireGroupAdmin', () => {
+  it('returns 403 when groupAuth is already set but isAdmin is false', async () => {
+    const { req, res, next, status } = makeReqRes({ communityDid: 'did:plc:community1' });
+    // Pre-populate groupAuth as requireGroupMember would
+    req.groupAuth = {
+      userDid: 'did:plc:user1',
+      communityDid: 'did:plc:community1',
+      isMember: true,
+      isAdmin: false,
+    };
+
+    await requireGroupAdmin(ctx)(req, res, next);
+
+    expect(status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+    // Must NOT call checkMembership again — groupAuth is already populated
+    expect(mockCheckMembership).not.toHaveBeenCalled();
+  });
+
+  it('calls next() when groupAuth is already set and isAdmin is true', async () => {
+    const { req, res, next } = makeReqRes({ communityDid: 'did:plc:community1' });
+    req.groupAuth = {
+      userDid: 'did:plc:admin1',
+      communityDid: 'did:plc:community1',
+      isMember: true,
+      isAdmin: true,
+    };
+
+    await requireGroupAdmin(ctx)(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(mockCheckMembership).not.toHaveBeenCalled();
+  });
+
+  it('performs full membership check when groupAuth is not pre-set', async () => {
+    mockGetSessionAgent.mockResolvedValue({ did: 'did:plc:admin1' } as any);
+    mockCheckMembership.mockResolvedValue({ isMember: true, isAdmin: true });
+    const { req, res, next } = makeReqRes({ communityDid: 'did:plc:community1' });
+
+    await requireGroupAdmin(ctx)(req, res, next);
+
+    expect(mockCheckMembership).toHaveBeenCalledWith('did:plc:community1', 'did:plc:admin1');
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(req.groupAuth?.isAdmin).toBe(true);
+  });
+
+  it('returns 403 when full check finds user is a member but not admin', async () => {
+    mockGetSessionAgent.mockResolvedValue({ did: 'did:plc:user1' } as any);
+    mockCheckMembership.mockResolvedValue({ isMember: true, isAdmin: false });
+    const { req, res, next, status } = makeReqRes({ communityDid: 'did:plc:community1' });
+
+    await requireGroupAdmin(ctx)(req, res, next);
+
+    expect(status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when no session even in standalone admin check', async () => {
+    mockGetSessionAgent.mockResolvedValue(null as any);
+    const { req, res, next, status } = makeReqRes({ communityDid: 'did:plc:community1' });
+
+    await requireGroupAdmin(ctx)(req, res, next);
+
+    expect(status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/test/integration/events.test.ts
+++ b/test/integration/events.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Integration tests — Events V1 endpoints
+ *
+ * Written against Wash's expected API contract. These tests will be
+ * INTENTIONALLY RED until Wash's branch (architecture cleanups + events backend)
+ * merges into main and the events routes exist.
+ *
+ * Expected endpoints (from task brief):
+ *   POST   /events                      — create event (admin only) → 201
+ *   GET    /events                      — list events with rsvpCounts
+ *   PUT    /events/:rkey/rsvp           — upsert RSVP (writes to PDS + event_rsvps)
+ *   DELETE /events/:rkey/rsvp           — remove RSVP
+ *   GET    /events/:rkey/rsvps          — grouped attendees
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import { createTestDb, cleanupTables, supertest } from './helpers';
+import express from 'express';
+import type { Database } from '../../src/db';
+import type { AppContext } from '../../src/context';
+import { pino } from 'pino';
+
+// ── Mock auth agent ───────────────────────────────────────────────────────────
+vi.mock('../../src/auth/agent', () => ({
+  getSessionAgent: vi.fn(),
+}));
+
+import { getSessionAgent } from '../../src/auth/agent';
+
+const ADMIN_DID = 'did:plc:admin001';
+const USER_DID = 'did:plc:user001';
+const EVENT_RKEY = 'evt-phase2-test';
+
+// Stub agent factory
+function makeAgent(did: string) {
+  return {
+    did,
+    putRecord: vi.fn(async () => ({ uri: `at://${did}/app.collectivesocial.event.rsvp/${EVENT_RKEY}`, cid: 'bafycid' })),
+    deleteRecord: vi.fn(async () => ({})),
+  };
+}
+
+// ── Attempt to import the events router (will fail until Wash's branch merges) ─
+
+let createEventsRouter: ((ctx: AppContext) => express.Router) | null = null;
+try {
+  // Dynamic import so the test file can still be parsed even when the module
+  // doesn't exist — the tests inside will fail with a descriptive message.
+  const mod = await import('../../src/routes/events');
+  createEventsRouter = mod.createRouter;
+} catch {
+  // Events router not yet implemented (Wash's branch pending)
+}
+
+function buildApp(ctx: AppContext): express.Express {
+  const app = express();
+  app.use(express.json());
+  if (createEventsRouter) {
+    app.use('/events', createEventsRouter(ctx));
+  } else {
+    // Placeholder so supertest gets 404 rather than a hard crash
+    app.use('/events', (_req, res) => res.status(501).json({ error: 'Not implemented — waiting on Wash branch' }));
+  }
+  return app;
+}
+
+function makeFakeCtx(db: Database): AppContext {
+  return {
+    db,
+    logger: pino({ level: 'silent' }),
+    oauthClient: { restore: async () => null } as any,
+    resolver: {} as any,
+    destroy: async () => { await db.destroy(); },
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('Events V1 — integration (⚠️ intentionally red until Wash branch merges)', () => {
+  let db: Database;
+  let app: express.Express;
+  let ctx: AppContext;
+
+  beforeAll(async () => {
+    db = await createTestDb();
+    ctx = makeFakeCtx(db);
+    app = buildApp(ctx);
+  });
+
+  afterAll(async () => {
+    await db.destroy();
+  });
+
+  beforeEach(async () => {
+    // Clean up event-related tables before each test.
+    // Table names are expected from Wash's migration — will error until merged.
+    await cleanupTables(db, ['events', 'event_rsvps']).catch(() => {
+      // Tables don't exist yet — ignore, test itself will surface the failure.
+    });
+    vi.clearAllMocks();
+  });
+
+  // ── POST /events ────────────────────────────────────────────────────────────
+
+  it('POST /events as admin returns 201 with event body', async () => {
+    vi.mocked(getSessionAgent).mockResolvedValue(makeAgent(ADMIN_DID) as any);
+
+    const payload = {
+      title: 'Phase 2 Launch Party',
+      description: 'We shipped it.',
+      startsAt: '2026-06-01T18:00:00.000Z',
+      endsAt: '2026-06-01T21:00:00.000Z',
+      location: 'The Internet',
+      communityDid: 'did:plc:community1',
+    };
+
+    const res = await supertest(app)
+      .post('/events')
+      .send(payload)
+      .expect(201);
+
+    expect(res.body).toMatchObject({
+      rkey: expect.any(String),
+      title: payload.title,
+      startsAt: payload.startsAt,
+    });
+  });
+
+  it('POST /events as non-admin returns 403', async () => {
+    vi.mocked(getSessionAgent).mockResolvedValue(makeAgent(USER_DID) as any);
+
+    await supertest(app)
+      .post('/events')
+      .send({ title: 'Sneaky event', communityDid: 'did:plc:community1' })
+      .expect(403);
+  });
+
+  // ── GET /events ─────────────────────────────────────────────────────────────
+
+  it('GET /events returns event list with rsvpCounts', async () => {
+    vi.mocked(getSessionAgent).mockResolvedValue(null);
+
+    const res = await supertest(app)
+      .get('/events')
+      .query({ communityDid: 'did:plc:community1' })
+      .expect(200);
+
+    expect(res.body).toHaveProperty('events');
+    expect(Array.isArray(res.body.events)).toBe(true);
+    // Each event must expose a rsvpCounts summary
+    if (res.body.events.length > 0) {
+      expect(res.body.events[0]).toHaveProperty('rsvpCounts');
+    }
+  });
+
+  // ── PUT /events/:rkey/rsvp ───────────────────────────────────────────────────
+
+  it('PUT /events/:rkey/rsvp upserts the PDS record and inserts into event_rsvps', async () => {
+    const agentMock = makeAgent(USER_DID);
+    vi.mocked(getSessionAgent).mockResolvedValue(agentMock as any);
+
+    const res = await supertest(app)
+      .put(`/events/${EVENT_RKEY}/rsvp`)
+      .send({ status: 'going', communityDid: 'did:plc:community1' })
+      .expect(200);
+
+    expect(agentMock.putRecord).toHaveBeenCalledOnce();
+    expect(res.body).toMatchObject({ status: 'going' });
+
+    // Verify DB row was inserted
+    const row = await (db as any)
+      .selectFrom('event_rsvps')
+      .selectAll()
+      .where('event_rkey', '=', EVENT_RKEY)
+      .where('user_did', '=', USER_DID)
+      .executeTakeFirst();
+
+    expect(row).toBeDefined();
+    expect(row.status).toBe('going');
+  });
+
+  // ── DELETE /events/:rkey/rsvp ────────────────────────────────────────────────
+
+  it('DELETE /events/:rkey/rsvp removes PDS record and DB row', async () => {
+    const agentMock = makeAgent(USER_DID);
+    vi.mocked(getSessionAgent).mockResolvedValue(agentMock as any);
+
+    await supertest(app)
+      .delete(`/events/${EVENT_RKEY}/rsvp`)
+      .send({ communityDid: 'did:plc:community1' })
+      .expect(200);
+
+    expect(agentMock.deleteRecord).toHaveBeenCalledOnce();
+
+    const row = await (db as any)
+      .selectFrom('event_rsvps')
+      .selectAll()
+      .where('event_rkey', '=', EVENT_RKEY)
+      .where('user_did', '=', USER_DID)
+      .executeTakeFirst();
+
+    expect(row).toBeUndefined();
+  });
+
+  // ── GET /events/:rkey/rsvps ──────────────────────────────────────────────────
+
+  it('GET /events/:rkey/rsvps returns attendees grouped by status', async () => {
+    vi.mocked(getSessionAgent).mockResolvedValue(null);
+
+    const res = await supertest(app)
+      .get(`/events/${EVENT_RKEY}/rsvps`)
+      .expect(200);
+
+    expect(res.body).toHaveProperty('rsvps');
+    // Grouped shape: { going: [...], maybe: [...], notGoing: [...] }
+    expect(res.body.rsvps).toHaveProperty('going');
+    expect(res.body.rsvps).toHaveProperty('maybe');
+    expect(res.body.rsvps).toHaveProperty('notGoing');
+  });
+});

--- a/test/integration/groups.test.ts
+++ b/test/integration/groups.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Integration tests — GET /groups/:communityDid/permissions
+ *
+ * These tests boot the Express app against a real test DB but mock the
+ * OpenSocial service so we aren't dependent on an external network call.
+ * The auth agent is also mocked to return null (unauthenticated) by default.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { createTestDb, createFakeContext, createTestApp, supertest } from './helpers';
+import type { Database } from '../../src/db';
+
+// ── Mock the OpenSocial service module ────────────────────────────────────────
+vi.mock('../../src/services/opensocial', () => ({
+  listCommunities: vi.fn(),
+  resolveUserPermissions: vi.fn(),
+  rkeyFromUri: vi.fn((uri: string) => uri.split('/').pop()),
+  getCommunityPermissions: vi.fn(),
+}));
+
+// ── Mock the auth agent (always unauthenticated in these tests) ───────────────
+vi.mock('../../src/auth/agent', () => ({
+  getSessionAgent: vi.fn(async () => null),
+}));
+
+import * as opensocial from '../../src/services/opensocial';
+
+const COMMUNITY_DID = 'did:plc:testcommunity123';
+
+const MOCK_PERMISSIONS: Record<string, {
+  canCreate: boolean; canRead: boolean; canUpdate: boolean; canDelete: boolean;
+}> = {
+  'app.collectivesocial.group.list': {
+    canCreate: false, canRead: true, canUpdate: false, canDelete: false,
+  },
+  'app.collectivesocial.group.listitem': {
+    canCreate: false, canRead: true, canUpdate: false, canDelete: false,
+  },
+};
+
+describe('GET /groups/:communityDid/permissions', () => {
+  let db: Database;
+  let app: ReturnType<typeof createTestApp>;
+
+  beforeAll(async () => {
+    db = await createTestDb();
+    const ctx = createFakeContext(db);
+    app = createTestApp(ctx);
+
+    vi.mocked(opensocial.resolveUserPermissions).mockResolvedValue(MOCK_PERMISSIONS);
+  });
+
+  afterAll(async () => {
+    await db.destroy();
+  });
+
+  it('returns 200 with a permissions object for an unauthenticated user', async () => {
+    const res = await supertest(app)
+      .get(`/groups/${COMMUNITY_DID}/permissions`)
+      .expect(200);
+
+    expect(res.body).toHaveProperty('permissions');
+    expect(res.body.permissions).toEqual(MOCK_PERMISSIONS);
+  });
+
+  it('calls resolveUserPermissions with the community DID and no userDid', async () => {
+    await supertest(app).get(`/groups/${COMMUNITY_DID}/permissions`);
+
+    expect(opensocial.resolveUserPermissions).toHaveBeenCalledWith(
+      COMMUNITY_DID,
+      undefined
+    );
+  });
+
+  it('returns 500 when opensocial throws', async () => {
+    vi.mocked(opensocial.resolveUserPermissions).mockRejectedValueOnce(
+      Object.assign(new Error('OpenSocial unavailable'), { status: 503 })
+    );
+
+    const res = await supertest(app)
+      .get(`/groups/${COMMUNITY_DID}/permissions`)
+      .expect(503);
+
+    expect(res.body).toHaveProperty('error');
+  });
+});

--- a/test/integration/helpers.ts
+++ b/test/integration/helpers.ts
@@ -1,0 +1,98 @@
+/**
+ * Integration test helpers for collective-social-api.
+ *
+ * createTestApp()  — boots a minimal Express app wired to the real routes but
+ *                    without starting a TCP listener (use supertest's request()).
+ * createTestDb()   — connects to the test postgres via DATABASE_URL_TEST and
+ *                    runs all Kysely migrations so the schema is up to date.
+ * cleanupTables()  — truncates named tables between tests to keep state clean.
+ */
+
+import express from 'express';
+import supertest from 'supertest';
+import { pino } from 'pino';
+import { Kysely, PostgresDialect } from 'kysely';
+import { Pool } from 'pg';
+import type { Database } from '../../src/db';
+import { migrateToLatest } from '../../src/migrations';
+import { createRouter as createGroupsRouter } from '../../src/routes/groups';
+import type { AppContext } from '../../src/context';
+
+// ── Test DB ───────────────────────────────────────────────────────────────────
+
+export async function createTestDb(): Promise<Database> {
+  const connectionString = process.env.DATABASE_URL_TEST;
+  if (!connectionString) {
+    throw new Error('DATABASE_URL_TEST env var is required for integration tests');
+  }
+
+  const db = new Kysely<import('../../src/db').DatabaseSchema>({
+    dialect: new PostgresDialect({
+      pool: new Pool({ connectionString, max: 5 }),
+    }),
+  }) as Database;
+
+  await migrateToLatest(db);
+  return db;
+}
+
+// ── Table cleanup ─────────────────────────────────────────────────────────────
+
+export async function cleanupTables(
+  db: Database,
+  tableNames: string[]
+): Promise<void> {
+  for (const table of tableNames) {
+    // RESTART IDENTITY resets serial PKs; CASCADE handles FK children.
+    await db.executeQuery(
+      // Raw SQL — Kysely doesn't have a first-class TRUNCATE builder.
+      (db as any).schema
+        .raw(`TRUNCATE TABLE "${table}" RESTART IDENTITY CASCADE`)
+        .compile()
+        .catch(() => {
+          // Fallback: just delete all rows if TRUNCATE isn't available via schema builder
+        })
+    ).catch(async () => {
+      await (db as any)
+        .deleteFrom(table as any)
+        .execute()
+        .catch(() => {
+          /* table may not exist in this migration snapshot — ignore */
+        });
+    });
+  }
+}
+
+// ── Minimal test app context ──────────────────────────────────────────────────
+
+/**
+ * Builds a fake AppContext with the real DB and no-op stubs for OAuth/logger.
+ * The agent is always null (unauthenticated) unless the test monkey-patches
+ * getSessionAgent via vi.mock.
+ */
+export function createFakeContext(db: Database): AppContext {
+  return {
+    db,
+    logger: pino({ level: 'silent' }),
+    oauthClient: {
+      restore: async () => null,
+    } as any,
+    resolver: {} as any,
+    destroy: async () => {
+      await db.destroy();
+    },
+  };
+}
+
+// ── Express app factory ───────────────────────────────────────────────────────
+
+export function createTestApp(ctx: AppContext): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use('/groups', createGroupsRouter(ctx));
+  return app;
+}
+
+// ── Convenience re-export so tests can call request(app) ─────────────────────
+
+export { supertest };

--- a/test/routes/reviewSegments.test.ts
+++ b/test/routes/reviewSegments.test.ts
@@ -1,8 +1,10 @@
 /**
  * Regression tests for the group segment progress route.
  *
- * Bug 1 (missing-createdAt): createCommunityRecord must include a `createdAt`
- *   timestamp so PDS records have a stable created_at field.
+ * Bug 1 (missing-createdAt): progress records must include a createdAt timestamp.
+ *   Originally tested against createCommunityRecord (community PDS path).
+ *   Updated for A.1 refactoring: progress now writes to the user's own PDS
+ *   via agent.api.com.atproto.repo.putRecord.
  *
  * Bug 2: unauthenticated / non-member requests must receive 403.
  */
@@ -48,8 +50,6 @@ import * as opensocial from '../../src/services/opensocial';
 const mockGetSessionAgent = vi.mocked(getSessionAgent);
 const mockCheckMembership = vi.mocked(opensocial.checkMembership);
 const mockGetCommunityRecord = vi.mocked(opensocial.getCommunityRecord);
-const mockListAllCommunityRecords = vi.mocked(opensocial.listAllCommunityRecords);
-const mockCreateCommunityRecord = vi.mocked(opensocial.createCommunityRecord);
 
 // ── Fixtures ──────────────────────────────────────────────────────
 
@@ -67,18 +67,6 @@ const segmentRecord = {
   },
 };
 
-const progressRecord = {
-  uri: `at://${COMMUNITY_DID}/app.collectivesocial.group.segment.progress/prog1`,
-  cid: 'bafycid2',
-  value: {
-    segmentUri: SEGMENT_URI,
-    memberDid: USER_DID,
-    completed: true,
-    completedAt: '2026-05-08T21:23:32.000Z',
-    createdAt: '2026-05-08T21:23:32.000Z',
-  },
-};
-
 // Minimal AppContext — db, config, logger all unused by these routes in tests.
 function makeCtx() {
   return {
@@ -92,7 +80,6 @@ function buildApp() {
   const ctx = makeCtx();
   const app = express();
   app.use(express.json());
-  // Mount with mergeParams to mirror real app: app.use('/groups/:communityDid', router)
   const router = express.Router({ mergeParams: true });
   router.use(createGroupContentRouter(ctx));
   app.use('/groups/:communityDid', router);
@@ -106,48 +93,63 @@ beforeEach(() => {
 // ── Tests ─────────────────────────────────────────────────────────
 
 describe('POST /groups/:communityDid/segments/:segmentRkey/progress', () => {
-  it('includes createdAt in the record sent to createCommunityRecord (regression: missing-createdAt bug)', async () => {
-    // Arrange: authenticated member
-    mockGetSessionAgent.mockResolvedValue({ did: USER_DID } as any);
+  it('writes to user PDS with createdAt (regression: missing-createdAt bug)', async () => {
+    // The putRecord and getRecord spies on the mock agent
+    const mockPutRecord = vi.fn().mockResolvedValue({
+      data: {
+        uri: `at://${USER_DID}/app.collectivesocial.feed.segmentprogress/${SEGMENT_RKEY}`,
+        cid: 'bafynewcid',
+      },
+    });
+    const mockGetRecord = vi.fn().mockRejectedValue(Object.assign(new Error('not found'), { status: 404 }));
+
+    mockGetSessionAgent.mockResolvedValue({
+      did: USER_DID,
+      api: {
+        com: {
+          atproto: {
+            repo: {
+              getRecord: mockGetRecord,
+              putRecord: mockPutRecord,
+            },
+          },
+        },
+      },
+    } as any);
     mockCheckMembership.mockResolvedValue({ isMember: true, isAdmin: false });
     mockGetCommunityRecord.mockResolvedValue(segmentRecord as any);
-    mockListAllCommunityRecords.mockResolvedValue([]);
-    mockCreateCommunityRecord.mockResolvedValue(progressRecord as any);
 
     const app = buildApp();
 
-    // Act
     const res = await request(app)
       .post(`/groups/${encodeURIComponent(COMMUNITY_DID)}/segments/${SEGMENT_RKEY}/progress`)
       .set('Cookie', 'session=fake');
 
-    // Assert: endpoint succeeded
     expect(res.status).toBe(200);
     expect(res.body.progress).toBeDefined();
 
-    // Assert: createdAt was forwarded to createCommunityRecord
-    expect(mockCreateCommunityRecord).toHaveBeenCalledTimes(1);
-    const [, , , record] = mockCreateCommunityRecord.mock.calls[0];
-    expect(record).toHaveProperty('createdAt');
-    expect(typeof (record as any).createdAt).toBe('string');
-    // Sanity check: completedAt is also present
-    expect(record).toHaveProperty('completedAt');
+    // Assert: putRecord was called with createdAt in the record
+    expect(mockPutRecord).toHaveBeenCalledTimes(1);
+    const callArgs = mockPutRecord.mock.calls[0][0];
+    expect(callArgs.collection).toBe('app.collectivesocial.feed.segmentprogress');
+    expect(callArgs.rkey).toBe(SEGMENT_RKEY);
+    expect(callArgs.record).toHaveProperty('createdAt');
+    expect(typeof callArgs.record.createdAt).toBe('string');
+    expect(callArgs.record).toHaveProperty('segmentUri', SEGMENT_URI);
+    expect(callArgs.record).toHaveProperty('completed', true);
+    expect(callArgs.record).toHaveProperty('communityDid', COMMUNITY_DID);
   });
 
   it('returns 403 when the user is not a member of the community', async () => {
-    // Arrange: authenticated but not a member
     mockGetSessionAgent.mockResolvedValue({ did: USER_DID } as any);
     mockCheckMembership.mockResolvedValue({ isMember: false, isAdmin: false });
 
     const app = buildApp();
 
-    // Act
     const res = await request(app)
       .post(`/groups/${encodeURIComponent(COMMUNITY_DID)}/segments/${SEGMENT_RKEY}/progress`)
       .set('Cookie', 'session=fake');
 
-    // Assert: membership gate is enforced
     expect(res.status).toBe(403);
-    expect(mockCreateCommunityRecord).not.toHaveBeenCalled();
   });
 });

--- a/test/routes/reviewSegments.test.ts
+++ b/test/routes/reviewSegments.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Regression tests for the group segment progress route.
+ *
+ * Bug 1 (missing-createdAt): createCommunityRecord must include a `createdAt`
+ *   timestamp so PDS records have a stable created_at field.
+ *
+ * Bug 2: unauthenticated / non-member requests must receive 403.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { createRouter as createGroupContentRouter } from '../../src/routes/groupContent';
+
+// ── Module mocks ──────────────────────────────────────────────────
+// vi.mock() is hoisted so these run before imports.
+
+vi.mock('../../src/auth/agent', () => ({
+  getSessionAgent: vi.fn(),
+}));
+
+vi.mock('../../src/services/opensocial', () => ({
+  checkMembership: vi.fn(),
+  getCommunityRecord: vi.fn(),
+  listAllCommunityRecords: vi.fn(),
+  createCommunityRecord: vi.fn(),
+  listAllCommunityRecordsByMember: vi.fn(),
+  rkeyFromUri: vi.fn((uri: string) => uri.split('/').pop() ?? ''),
+}));
+
+// Notifications & group-post service — not under test, silence them
+vi.mock('../../src/services/notifications', () => ({
+  createNotification: vi.fn().mockResolvedValue(undefined),
+  notifyAllMembers: vi.fn().mockResolvedValue(undefined),
+  notifyUsers: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../src/services/groupPosts', () => ({
+  getPostsForSegment: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../../src/services/userProfiles', () => ({
+  getUserProfile: vi.fn().mockResolvedValue(null),
+}));
+
+import { getSessionAgent } from '../../src/auth/agent';
+import * as opensocial from '../../src/services/opensocial';
+
+const mockGetSessionAgent = vi.mocked(getSessionAgent);
+const mockCheckMembership = vi.mocked(opensocial.checkMembership);
+const mockGetCommunityRecord = vi.mocked(opensocial.getCommunityRecord);
+const mockListAllCommunityRecords = vi.mocked(opensocial.listAllCommunityRecords);
+const mockCreateCommunityRecord = vi.mocked(opensocial.createCommunityRecord);
+
+// ── Fixtures ──────────────────────────────────────────────────────
+
+const COMMUNITY_DID = 'did:plc:community1';
+const USER_DID = 'did:plc:user1';
+const SEGMENT_RKEY = 'seg123';
+const SEGMENT_URI = `at://${COMMUNITY_DID}/app.collectivesocial.group.segment/${SEGMENT_RKEY}`;
+
+const segmentRecord = {
+  uri: SEGMENT_URI,
+  cid: 'bafycid',
+  value: {
+    label: 'Chapters 1-5',
+    listItemUri: `at://${COMMUNITY_DID}/app.collectivesocial.group.listitem/item1`,
+  },
+};
+
+const progressRecord = {
+  uri: `at://${COMMUNITY_DID}/app.collectivesocial.group.segment.progress/prog1`,
+  cid: 'bafycid2',
+  value: {
+    segmentUri: SEGMENT_URI,
+    memberDid: USER_DID,
+    completed: true,
+    completedAt: '2026-05-08T21:23:32.000Z',
+    createdAt: '2026-05-08T21:23:32.000Z',
+  },
+};
+
+// Minimal AppContext — db, config, logger all unused by these routes in tests.
+function makeCtx() {
+  return {
+    logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+    db: {},
+    cfg: {},
+  } as any;
+}
+
+function buildApp() {
+  const ctx = makeCtx();
+  const app = express();
+  app.use(express.json());
+  // Mount with mergeParams to mirror real app: app.use('/groups/:communityDid', router)
+  const router = express.Router({ mergeParams: true });
+  router.use(createGroupContentRouter(ctx));
+  app.use('/groups/:communityDid', router);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── Tests ─────────────────────────────────────────────────────────
+
+describe('POST /groups/:communityDid/segments/:segmentRkey/progress', () => {
+  it('includes createdAt in the record sent to createCommunityRecord (regression: missing-createdAt bug)', async () => {
+    // Arrange: authenticated member
+    mockGetSessionAgent.mockResolvedValue({ did: USER_DID } as any);
+    mockCheckMembership.mockResolvedValue({ isMember: true, isAdmin: false });
+    mockGetCommunityRecord.mockResolvedValue(segmentRecord as any);
+    mockListAllCommunityRecords.mockResolvedValue([]);
+    mockCreateCommunityRecord.mockResolvedValue(progressRecord as any);
+
+    const app = buildApp();
+
+    // Act
+    const res = await request(app)
+      .post(`/groups/${encodeURIComponent(COMMUNITY_DID)}/segments/${SEGMENT_RKEY}/progress`)
+      .set('Cookie', 'session=fake');
+
+    // Assert: endpoint succeeded
+    expect(res.status).toBe(200);
+    expect(res.body.progress).toBeDefined();
+
+    // Assert: createdAt was forwarded to createCommunityRecord
+    expect(mockCreateCommunityRecord).toHaveBeenCalledTimes(1);
+    const [, , , record] = mockCreateCommunityRecord.mock.calls[0];
+    expect(record).toHaveProperty('createdAt');
+    expect(typeof (record as any).createdAt).toBe('string');
+    // Sanity check: completedAt is also present
+    expect(record).toHaveProperty('completedAt');
+  });
+
+  it('returns 403 when the user is not a member of the community', async () => {
+    // Arrange: authenticated but not a member
+    mockGetSessionAgent.mockResolvedValue({ did: USER_DID } as any);
+    mockCheckMembership.mockResolvedValue({ isMember: false, isAdmin: false });
+
+    const app = buildApp();
+
+    // Act
+    const res = await request(app)
+      .post(`/groups/${encodeURIComponent(COMMUNITY_DID)}/segments/${SEGMENT_RKEY}/progress`)
+      .set('Cookie', 'session=fake');
+
+    // Assert: membership gate is enforced
+    expect(res.status).toBe(403);
+    expect(mockCreateCommunityRecord).not.toHaveBeenCalled();
+  });
+});

--- a/vitest.config.integration.ts
+++ b/vitest.config.integration.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from 'vitest/config';
+
+const dbUrl = process.env.DATABASE_URL_TEST;
+if (!dbUrl) {
+  throw new Error(
+    'DATABASE_URL_TEST must be set to run integration tests.\n' +
+      'Example: DATABASE_URL_TEST=postgresql://user:pass@localhost:5432/collective_social_test npm run test:integration'
+  );
+}
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['test/integration/**/*.test.ts'],
+    testTimeout: 30000,
+    hookTimeout: 30000,
+    // Run integration tests serially to avoid DB contention
+    pool: 'forks',
+    poolOptions: {
+      forks: {
+        singleFork: true,
+      },
+    },
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['test/**/*.test.ts'],
+    exclude: ['test/integration/**'],
     testTimeout: 10000,
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
Phase 2 backend work building on Phase 1 auth migration. Includes architecture cleanups and Events V1.

## What's in this branch

### Architecture cleanups
- **Segment progress → user PDS (B1):** Segment progress now written to the user's own ATProto PDS instead of the shared DB; hybrid read path maintained during transition (B5)
- **strongRef upgrade:** `group.postindex.postUri` upgraded to use strongRef
- **Fake CID removal:** Stripped all fabricated CIDs from the codebase
- **Orphan cleanup:** Stale orphan records removed

### Events V1 backend
- Migration 028: `event_rsvps` table
- Routes and service layer for events
- DEFAULTS configured
- Regression test updated for segment progress user-PDS path

### Tests
- Integration tests + expanded coverage + test infra bootstrap

## ⚠️ FLAG F5 — API Contract Change
Segment progress API contract changed. **Deploy this backend before `phase2-events-ui` in collective-social-web.** Coordinate deploys.

## Notes
- **F6 follow-up:** `community.lexicon.calendar.rsvp` JSON ownership not resolved here — tracked separately
⚠️ **F7 follow-up:** Some tests require `DATABASE_URL_TEST` env var — intentionally red in CI until configured