### PR TITLE
Hotfix: discussion comment permissions regression for members

### DIFF
--- a/src/services/opensocial.ts
+++ b/src/services/opensocial.ts
@@ -501,22 +501,9 @@ export async function resolveUserPermissions(
     return userRoles.includes(requiredRole);
   };
 
-  // If we got permission rows from open-social, use them
-  if (permissions.length > 0) {
-    const result: Record<string, ResolvedCollectionPermission> = {};
-    for (const perm of permissions) {
-      result[perm.collection] = {
-        canCreate: resolve(perm.canCreate),
-        canRead: resolve(perm.canRead),
-        canUpdate: resolve(perm.canUpdate),
-        canDelete: resolve(perm.canDelete),
-      };
-    }
-    return result;
-  }
-
-  // Fallback: no permission rows (app not enabled yet).
-  // Use hardcoded defaults matching the original middleware behavior.
+  // Hardcoded defaults matching the original middleware behavior.
+  // Used as a baseline so that collections not yet seeded in the DB are
+  // always present. DB rows take precedence when they exist.
   const DEFAULTS: Record<
     string,
     { c: string; r: string; u: string; d: string }
@@ -573,6 +560,7 @@ export async function resolveUserPermissions(
     },
   };
 
+  // Build from DEFAULTS as baseline
   const result: Record<string, ResolvedCollectionPermission> = {};
   for (const [col, def] of Object.entries(DEFAULTS)) {
     result[col] = {
@@ -582,5 +570,17 @@ export async function resolveUserPermissions(
       canDelete: resolve(def.d),
     };
   }
+
+  // Overlay DB rows: community-specific overrides take precedence over DEFAULTS.
+  // Also covers collections not in DEFAULTS (e.g. app-specific custom collections).
+  for (const perm of permissions) {
+    result[perm.collection] = {
+      canCreate: resolve(perm.canCreate),
+      canRead: resolve(perm.canRead),
+      canUpdate: resolve(perm.canUpdate),
+      canDelete: resolve(perm.canDelete),
+    };
+  }
+
   return result;
 }

--- a/test/opensocial.test.ts
+++ b/test/opensocial.test.ts
@@ -8,6 +8,19 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock config so the request() guard doesn't throw in CI where
+// OPENSOCIAL_API_KEY / OPENSOCIAL_SIGNING_KEY aren't set.
+vi.mock('../src/config', () => ({
+  config: {
+    openSocialApiUrl: 'http://localhost:3001',
+    openSocialApiKey: 'test-api-key',
+    openSocialSigningKey: '',
+    openSocialKeyId: '',
+    openSocialKeyAlgorithm: '',
+  },
+}));
+
 import { resolveUserPermissions } from '../src/services/opensocial';
 
 // Mock fetch globally so no real HTTP calls are made.

--- a/test/opensocial.test.ts
+++ b/test/opensocial.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Unit tests for resolveUserPermissions in src/services/opensocial.ts
+ *
+ * Regression tests for the bug where DB permission rows were returned
+ * as-is (skipping DEFAULTS), leaving app.collectivesocial.group.post
+ * absent from the result — causing the frontend to treat members as
+ * non-members for the discussion comment gate.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { resolveUserPermissions } from '../src/services/opensocial';
+
+// Mock fetch globally so no real HTTP calls are made.
+// Each test provides its own mock return value via mockFetch().
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+const MEMBER_DID = 'did:plc:member';
+const ADMIN_DID = 'did:plc:admin';
+
+/** Helper: set up a fetch mock returning the given permissions response. */
+function setupPermissionsMock(
+  permissions: Array<{ collection: string; canCreate: string; canRead: string; canUpdate: string; canDelete: string }>,
+  userRoles: string[],
+) {
+  const body = JSON.stringify({ permissions, userRoles });
+  mockFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({ permissions, userRoles }),
+    text: async () => body,
+  });
+}
+
+// Use a unique community DID per test to bypass the module-level permissions cache.
+let testCounter = 0;
+function uniqueDid() {
+  return `did:plc:testcommunity${++testCounter}`;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('resolveUserPermissions', () => {
+  it('includes app.collectivesocial.group.post with canCreate=true for a member even when DB rows exist for other collections', async () => {
+    // Simulate a community that has DB rows for list/listitem but NOT group.post.
+    // This was the bug: the early-return on permissions.length > 0 skipped DEFAULTS,
+    // leaving group.post absent from the result entirely.
+    setupPermissionsMock(
+      [
+        { collection: 'app.collectivesocial.group.list', canCreate: 'admin', canRead: 'member', canUpdate: 'admin', canDelete: 'admin' },
+        { collection: 'app.collectivesocial.group.listitem', canCreate: 'admin', canRead: 'member', canUpdate: 'admin', canDelete: 'admin' },
+      ],
+      ['member'],
+    );
+
+    const result = await resolveUserPermissions(uniqueDid(), MEMBER_DID);
+
+    expect(result['app.collectivesocial.group.post']).toBeDefined();
+    expect(result['app.collectivesocial.group.post'].canCreate).toBe(true);
+    expect(result['app.collectivesocial.group.post'].canRead).toBe(true);
+  });
+
+  it('gives an admin canCreate=true for group.post even when DB rows omit it', async () => {
+    setupPermissionsMock(
+      [{ collection: 'app.collectivesocial.group.list', canCreate: 'admin', canRead: 'member', canUpdate: 'admin', canDelete: 'admin' }],
+      ['admin'],
+    );
+
+    const result = await resolveUserPermissions(uniqueDid(), ADMIN_DID);
+
+    expect(result['app.collectivesocial.group.post'].canCreate).toBe(true);
+  });
+
+  it('DB rows override DEFAULTS when the same collection appears in both', async () => {
+    // Community has overridden group.post to require admin to create (not the DEFAULTS member)
+    setupPermissionsMock(
+      [{ collection: 'app.collectivesocial.group.post', canCreate: 'admin', canRead: 'member', canUpdate: 'admin', canDelete: 'admin' }],
+      ['member'],
+    );
+
+    const result = await resolveUserPermissions(uniqueDid(), MEMBER_DID);
+
+    expect(result['app.collectivesocial.group.post'].canCreate).toBe(false);
+    expect(result['app.collectivesocial.group.post'].canRead).toBe(true);
+  });
+
+  it('falls back entirely to DEFAULTS when no DB rows exist', async () => {
+    setupPermissionsMock([], ['member']);
+
+    const result = await resolveUserPermissions(uniqueDid(), MEMBER_DID);
+
+    expect(result['app.collectivesocial.group.post'].canCreate).toBe(true);
+    expect(result['app.collectivesocial.group.list'].canCreate).toBe(false); // admin-only in DEFAULTS
+    expect(result['app.collectivesocial.group.list'].canRead).toBe(true);
+  });
+
+  it('returns canCreate=false for group.post when user has no roles', async () => {
+    setupPermissionsMock([], []);
+
+    const result = await resolveUserPermissions(uniqueDid(), MEMBER_DID);
+
+    expect(result['app.collectivesocial.group.post'].canCreate).toBe(false);
+  });
+
+  it('returns all false when userDid is undefined (unauthenticated)', async () => {
+    setupPermissionsMock([], []);
+
+    const result = await resolveUserPermissions(uniqueDid(), undefined);
+
+    expect(result['app.collectivesocial.group.post'].canCreate).toBe(false);
+    expect(result['app.collectivesocial.group.post'].canRead).toBe(false);
+  });
+
+  it('includes all DEFAULTS collections even when DB has unrelated rows', async () => {
+    setupPermissionsMock(
+      [{ collection: 'community.lexicon.calendar.event', canCreate: 'admin', canRead: 'member', canUpdate: 'admin', canDelete: 'admin' }],
+      ['member'],
+    );
+
+    const result = await resolveUserPermissions(uniqueDid(), MEMBER_DID);
+
+    const expectedCollections = [
+      'app.collectivesocial.group.list',
+      'app.collectivesocial.group.listitem',
+      'app.collectivesocial.group.listitem.status',
+      'app.collectivesocial.group.segment',
+      'app.collectivesocial.group.segment.progress',
+      'app.collectivesocial.group.post',
+      'app.collectivesocial.group.reaction',
+      'community.lexicon.calendar.event',
+    ];
+
+    for (const col of expectedCollections) {
+      expect(result[col], `Missing collection: ${col}`).toBeDefined();
+    }
+  });
+});
+


### PR DESCRIPTION
## 🐛 Symptom
On a group discussion page where Brittany IS a member, the UI showed "You need to be a group member to comment on this discussion." She could not post comments.

⚠️ **BLOCKED Brittany using her own product — please prioritize merge**

## 🔍 Root cause

`resolveUserPermissions` in `src/services/opensocial.ts` had an early-return when `permissions.length > 0` that skipped the hardcoded DEFAULTS entirely. If open-social's DB had permission rows for the community but those rows omitted `app.collectivesocial.group.post` (e.g. partial seeding), the collection was missing from the response map.

The frontend (Phase 1 branch) reads `permissions['app.collectivesocial.group.post']` → `undefined`. The Phase 1 ternary `{postPerm?.canCreate ? form : message}` treated `undefined` (falsy) identically to `false`, incorrectly showing the denial message to members.

The backend DB-rows-or-DEFAULTS either/or logic is the primary bug; the frontend is a second layer that surfaced it.

## 🩹 Fix

In `src/services/opensocial.ts`, changed `resolveUserPermissions` to always build from DEFAULTS as a baseline, then overlay DB rows on top. This ensures `app.collectivesocial.group.post` (and all other DEFAULTS collections) are always present in the response, even when DB rows are incomplete. Community-specific overrides still take precedence over DEFAULTS.

The early-return block (lines 504–516) was removed and replaced with a two-pass approach: DEFAULTS first, then DB overlay.

## 🧪 Regression test added

`test/opensocial.test.ts` — 7 new unit tests for `resolveUserPermissions`:
- Member gets `canCreate=true` for `group.post` even when DB rows omit it
- Admin gets `canCreate=true` even when DB rows omit it
- DB rows override DEFAULTS when same collection appears in both
- Pure DEFAULTS fallback when no DB rows
- No-roles user gets `canCreate=false`
- Unauthenticated user (undefined userDid) gets all false
- All DEFAULTS collections present when DB has unrelated rows

## 🔗 Paired PR

Frontend defensive guard: collectivesocial/collective-social-web#... (squad/hotfix-discussion-permissions targeting squad/phase1-frontend-bugs)

## ⚠️ Adjacent bug (NOT fixed here — follow-up required)

Phase 2 changed the `GET /items/:rkey/progress` response format from `Record<segUri, Array<{memberDid,...}>>` to `Record<segUri, {completed,...} | null>`. The frontend's `myProgressSet` useEffect still calls `.some()` on each value — would TypeError on non-array, leaving `myProgressSet` empty. This breaks the spoiler gate for non-admin members (they can't see discussions). Should be fixed separately after this hotfix merges.