### PR TITLE
fix: resolve author PDS for cross-PDS group post visibility

### DIFF
--- a/src/services/groupPosts.ts
+++ b/src/services/groupPosts.ts
@@ -1,6 +1,7 @@
 import { Agent } from '@atproto/api';
 import { TID } from '@atproto/common';
 import * as opensocial from './opensocial';
+import { config } from '../config';
 
 const COL_GROUP_POST_PERSONAL = 'app.collectivesocial.feed.grouppost';
 const COL_POST_INDEX = 'app.collectivesocial.group.postindex';
@@ -19,6 +20,34 @@ export interface GroupPost {
   createdAt: string;
   replies?: GroupPost[];
   isLegacy?: boolean;
+}
+
+/**
+ * Resolve the PDS endpoint for a DID by fetching its DID document.
+ * Handles did:plc (via PLC directory) and did:web (via .well-known).
+ */
+export async function resolvePdsUrl(did: string): Promise<string> {
+  let docUrl: string;
+  if (did.startsWith('did:web:')) {
+    const host = did.replace('did:web:', '');
+    docUrl = `https://${host}/.well-known/did.json`;
+  } else {
+    docUrl = `${config.plcUrl}/${did}`;
+  }
+
+  const res = await fetch(docUrl);
+  if (!res.ok) {
+    throw new Error(`Failed to resolve DID document for ${did}: ${res.status}`);
+  }
+  const doc = (await res.json()) as any;
+
+  const pdsService = doc.service?.find(
+    (s: any) => s.id === '#atproto_pds' || s.type === 'AtprotoPersonalDataServer'
+  );
+  if (!pdsService?.serviceEndpoint) {
+    throw new Error(`No PDS service endpoint found in DID document for ${did}`);
+  }
+  return pdsService.serviceEndpoint;
 }
 
 /**
@@ -116,7 +145,7 @@ export async function fetchGroupPosts(
     return true;
   });
 
-  // 3. Fetch actual posts from user repos in parallel
+  // 3. Fetch actual posts from author PDS endpoints in parallel
   const posts: GroupPost[] = [];
   await Promise.all(
     relevantIndexes.map(async (idx: any) => {
@@ -126,16 +155,27 @@ export async function fetchGroupPosts(
         if (!match) return;
 
         const [, ownerDid, collection, rkey] = match;
-        const postResponse = await agent.api.com.atproto.repo.getRecord({
-          repo: ownerDid,
-          collection: collection,
-          rkey: rkey,
-        });
+
+        // Resolve the author's PDS and fetch the record directly.
+        // Group posts are public, so no auth is needed. This works
+        // regardless of which PDS the requesting user is on.
+        const pdsUrl = await resolvePdsUrl(ownerDid);
+        const getRecordUrl = new URL('/xrpc/com.atproto.repo.getRecord', pdsUrl);
+        getRecordUrl.searchParams.set('repo', ownerDid);
+        getRecordUrl.searchParams.set('collection', collection);
+        getRecordUrl.searchParams.set('rkey', rkey);
+
+        const postRes = await fetch(getRecordUrl.toString());
+        if (!postRes.ok) {
+          console.warn(`PDS returned ${postRes.status} for ${postUri}`);
+          return;
+        }
+        const postData = (await postRes.json()) as any;
 
         posts.push({
           uri: postUri,
           rkey: rkey,
-          ...(postResponse.data.value as any),
+          ...(postData.value as any),
           authorDid: ownerDid,
         });
       } catch (err) {

--- a/test/groupPosts.test.ts
+++ b/test/groupPosts.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock config so we control plcUrl
+vi.mock('../src/config', () => ({
+  config: {
+    plcUrl: 'https://plc.directory',
+    openSocialApiUrl: 'http://localhost:3001',
+    openSocialApiKey: 'test-api-key',
+    openSocialSigningKey: '',
+    openSocialKeyId: '',
+    openSocialKeyAlgorithm: '',
+  },
+}));
+
+// Mock opensocial to control index records returned
+vi.mock('../src/services/opensocial', () => ({
+  listAllCommunityRecords: vi.fn(),
+}));
+
+import { fetchGroupPosts, resolvePdsUrl } from '../src/services/groupPosts';
+import * as opensocial from '../src/services/opensocial';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+const COMMUNITY_DID = 'did:plc:community123';
+const AUTHOR_DID = 'did:plc:author456';
+const REQUESTER_DID = 'did:plc:requester789';
+const SEGMENT_URI = 'at://did:plc:community123/app.collectivesocial.group.segment/abc';
+const POST_RKEY = 'post-rkey-1';
+const POST_URI = `at://${AUTHOR_DID}/app.collectivesocial.feed.grouppost/${POST_RKEY}`;
+const AUTHOR_PDS = 'https://author.pds.example';
+
+function makeDIDDoc(did: string, pdsEndpoint: string) {
+  return {
+    id: did,
+    service: [
+      { id: '#atproto_pds', type: 'AtprotoPersonalDataServer', serviceEndpoint: pdsEndpoint },
+    ],
+  };
+}
+
+function makeIndexRecord(postUri: string, authorDid: string, segmentUri: string) {
+  return {
+    uri: `at://${COMMUNITY_DID}/app.collectivesocial.group.postindex/idx-1`,
+    value: {
+      post: { uri: postUri, cid: 'bafyabc' },
+      authorDid,
+      segmentUri,
+      deletedByAdmin: false,
+      createdAt: '2026-01-01T00:00:00Z',
+    },
+  };
+}
+
+// Stub agent (not used for fetching anymore, but still passed to the function)
+const fakeAgent = { did: REQUESTER_DID, api: { com: { atproto: { repo: { getRecord: vi.fn() } } } } } as any;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('fetchGroupPosts', () => {
+  it('non-author sees posts via direct PDS fetch', async () => {
+    // Index returns one post by AUTHOR_DID
+    vi.mocked(opensocial.listAllCommunityRecords).mockResolvedValue([
+      makeIndexRecord(POST_URI, AUTHOR_DID, SEGMENT_URI),
+    ]);
+
+    // fetch call 1: DID doc for author
+    // fetch call 2: getRecord from author's PDS
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => makeDIDDoc(AUTHOR_DID, AUTHOR_PDS) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          uri: POST_URI,
+          value: { text: 'hello from author', createdAt: '2026-01-01T00:00:00Z' },
+        }),
+      });
+
+    const posts = await fetchGroupPosts(fakeAgent, COMMUNITY_DID, { segmentUri: SEGMENT_URI });
+
+    expect(posts).toHaveLength(1);
+    expect(posts[0].text).toBe('hello from author');
+    expect(posts[0].authorDid).toBe(AUTHOR_DID);
+
+    // Agent's getRecord should never be called
+    expect(fakeAgent.api.com.atproto.repo.getRecord).not.toHaveBeenCalled();
+  });
+
+  it('author sees own posts via same direct PDS fetch path', async () => {
+    const authorAgent = { did: AUTHOR_DID, api: { com: { atproto: { repo: { getRecord: vi.fn() } } } } } as any;
+
+    vi.mocked(opensocial.listAllCommunityRecords).mockResolvedValue([
+      makeIndexRecord(POST_URI, AUTHOR_DID, SEGMENT_URI),
+    ]);
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => makeDIDDoc(AUTHOR_DID, AUTHOR_PDS) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          uri: POST_URI,
+          value: { text: 'my own post', createdAt: '2026-01-01T00:00:00Z' },
+        }),
+      });
+
+    const posts = await fetchGroupPosts(authorAgent, COMMUNITY_DID, { segmentUri: SEGMENT_URI });
+
+    expect(posts).toHaveLength(1);
+    expect(posts[0].text).toBe('my own post');
+    expect(authorAgent.api.com.atproto.repo.getRecord).not.toHaveBeenCalled();
+  });
+
+  it('returns empty array when PDS resolution fails (PLC 404)', async () => {
+    vi.mocked(opensocial.listAllCommunityRecords).mockResolvedValue([
+      makeIndexRecord(POST_URI, AUTHOR_DID, SEGMENT_URI),
+    ]);
+
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
+
+    const posts = await fetchGroupPosts(fakeAgent, COMMUNITY_DID, { segmentUri: SEGMENT_URI });
+    expect(posts).toEqual([]);
+  });
+
+  it('returns empty array when PDS getRecord fails (PDS 404)', async () => {
+    vi.mocked(opensocial.listAllCommunityRecords).mockResolvedValue([
+      makeIndexRecord(POST_URI, AUTHOR_DID, SEGMENT_URI),
+    ]);
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => makeDIDDoc(AUTHOR_DID, AUTHOR_PDS) })
+      .mockResolvedValueOnce({ ok: false, status: 404 });
+
+    const posts = await fetchGroupPosts(fakeAgent, COMMUNITY_DID, { segmentUri: SEGMENT_URI });
+    expect(posts).toEqual([]);
+  });
+
+  it('skips posts marked deletedByAdmin before any network call', async () => {
+    const deletedIndex = makeIndexRecord(POST_URI, AUTHOR_DID, SEGMENT_URI);
+    deletedIndex.value.deletedByAdmin = true;
+
+    vi.mocked(opensocial.listAllCommunityRecords).mockResolvedValue([deletedIndex]);
+
+    const posts = await fetchGroupPosts(fakeAgent, COMMUNITY_DID, { segmentUri: SEGMENT_URI });
+
+    expect(posts).toEqual([]);
+    // No fetch calls for DID doc or PDS
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('skips posts with mismatched segmentUri before any network call', async () => {
+    vi.mocked(opensocial.listAllCommunityRecords).mockResolvedValue([
+      makeIndexRecord(POST_URI, AUTHOR_DID, 'at://different/segment/uri'),
+    ]);
+
+    const posts = await fetchGroupPosts(fakeAgent, COMMUNITY_DID, { segmentUri: SEGMENT_URI });
+
+    expect(posts).toEqual([]);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolvePdsUrl', () => {
+  it('resolves did:plc via PLC directory', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => makeDIDDoc('did:plc:test', 'https://my.pds.example'),
+    });
+
+    const url = await resolvePdsUrl('did:plc:test');
+    expect(url).toBe('https://my.pds.example');
+    expect(mockFetch).toHaveBeenCalledWith('https://plc.directory/did:plc:test');
+  });
+
+  it('resolves did:web via .well-known', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => makeDIDDoc('did:web:example.com', 'https://pds.example.com'),
+    });
+
+    const url = await resolvePdsUrl('did:web:example.com');
+    expect(url).toBe('https://pds.example.com');
+    expect(mockFetch).toHaveBeenCalledWith('https://example.com/.well-known/did.json');
+  });
+
+  it('throws when DID document has no PDS service', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 'did:plc:nopds', service: [] }),
+    });
+
+    await expect(resolvePdsUrl('did:plc:nopds')).rejects.toThrow('No PDS service endpoint');
+  });
+});


### PR DESCRIPTION
## What

`GET /groups/:communityDid/segments/:segmentRkey/posts` returns empty results for group members who are not the post author. The author sees their own posts fine; everyone else sees `{"posts":[]}`. HTTP 200 in both cases hides the failure.

## Why

Collective Social uses dual storage for group posts:
- **Post content** lives in the author's personal ATProto repo (`app.collectivesocial.feed.grouppost`)
- **An index pointer** lives in the community repo (`app.collectivesocial.group.postindex`)

`fetchGroupPosts` in `src/services/groupPosts.ts` was using the **requesting user's** ATProto agent to fetch post records:

```typescript
await agent.api.com.atproto.repo.getRecord({
  repo: ownerDid, // author's DID
  collection,
  rkey,
});
```

The agent is pre-configured to talk to the **requester's PDS**. When author and requester are on different PDS hosts, the requester's PDS cannot serve the author's records. The call fails silently in a `try/catch` and the post is dropped.

## How

Two changes in `src/services/groupPosts.ts`:

1. **Added `resolvePdsUrl(did)`**: looks up the DID document (from PLC directory for `did:plc`, or `.well-known` for `did:web`) and extracts the `AtprotoPersonalDataServer` service endpoint.

2. **Replaced the agent call with a direct `fetch`** to the author's own PDS:

```typescript
const pdsUrl = await resolvePdsUrl(ownerDid);
const getRecordUrl = new URL("/xrpc/com.atproto.repo.getRecord", pdsUrl);
getRecordUrl.searchParams.set("repo", ownerDid);
getRecordUrl.searchParams.set("collection", collection);
getRecordUrl.searchParams.set("rkey", rkey);
const postRes = await fetch(getRecordUrl.toString());
```

Group posts are public records, so no auth is needed. This works regardless of which PDS the requesting user is on.

## Risks and tradeoffs

**Performance**: each post now requires 2 network calls instead of 1 (DID doc resolve + getRecord). 10 posts by the same author means 10 identical PLC directory lookups. A follow-up PR should add an in-memory PDS URL cache with TTL and cache-bust-on-failure for PDS migrations.

**Failure mode unchanged**: if PLC directory is down or the author's PDS is unreachable, the post is still silently dropped (same `try/catch` behavior as before). No worse, but no better. Improving observability here is a follow-up.

**No impact on writes**: `createGroupPost`, `deleteGroupPost`, and `adminDeleteGroupPost` still use the agent (they write to the caller's own repo, where same-PDS is correct).

**Legacy path untouched**: `fetchGroupPostsWithLegacy` calls this function, so legacy posts fetched directly from the community repo are unaffected.

## Tests

9 tests added in `test/groupPosts.test.ts`:

| Test | Verifies |
|---|---|
| Non-author sees posts | Cross-PDS fetch works; agent getRecord never called |
| Author sees own posts | Same direct-fetch path used even for the author |
| PDS resolution failure (PLC 404) | Returns `[]` instead of throwing |
| PDS getRecord failure (PDS 404) | Returns `[]` instead of throwing |
| `deletedByAdmin: true` | Skipped before any network call |
| `segmentUri` mismatch | Skipped before any network call |
| `resolvePdsUrl` did:plc | Resolves via PLC directory |
| `resolvePdsUrl` did:web | Resolves via .well-known |
| `resolvePdsUrl` no PDS service | Throws descriptive error |

## How to validate on rollout

1. **Smoke test**: have two users on different PDS hosts in the same group. User A creates a post. User B loads the segment. User B should now see the post.
2. **Watch logs** for `"Failed to fetch post"` and `"PDS returned"` warnings. A spike would indicate PDS resolution issues.
3. **Check latency**: the extra PLC directory call adds ~50-200ms per unique author per request. If this becomes noticeable, prioritize the caching follow-up.
4. **Verify writes still work**: create, delete, and admin-delete a post to confirm those paths are unaffected.

## Follow-ups

- [ ] Add in-memory PDS URL cache with TTL + cache-bust on PDS fetch failure (handles migrations)
- [ ] Improve observability: structured logging instead of `console.warn`
- [ ] SPA 404 issue: hosting layer needs a catch-all rule to serve `index.html` for client-side routes (unrelated)
